### PR TITLE
Fix mobile start menu and mobile zoom

### DIFF
--- a/beamer/style.css
+++ b/beamer/style.css
@@ -82,12 +82,11 @@ body {
 /* Mobile scaling adjustments */
 @media (max-width: 1023px) {
   #game {
-    width: 100vw;
     height: 100vh;
-    max-width: none;
-    max-height: none;
+    width: auto;
+    max-width: 100vw;
   }
-  
+
   body {
     overflow: hidden;
   }

--- a/jump-kids/game.js
+++ b/jump-kids/game.js
@@ -368,6 +368,8 @@ async function startFromMenu(){
   playBeep(700,0.08,0.08);
 }
 startBtn.addEventListener('click', startFromMenu);
+// On some mobile browsers the click event may be delayed; trigger on touch as well
+startBtn.addEventListener('touchstart', (e)=>{ e.preventDefault(); startFromMenu(); });
 document.addEventListener('keydown', (e)=>{ if (menuEl && !menuEl.classList.contains('hidden') && (e.key==='Enter' || e.key===' ')) startFromMenu(); });
 
 // Input

--- a/jump-kids/index.html
+++ b/jump-kids/index.html
@@ -42,34 +42,36 @@
   <div class="menu-card">
     <h1 class="menu-title arcade">Jump Kids</h1>
 
-    <div class="menu-section">
-      <div class="menu-section-title">Select Level</div>
-      <div id="levelGrid" class="level-grid" aria-label="Level select"></div>
-      <div class="sr-only">
-        <label for="levelSelect">Level</label>
-        <select id="levelSelect" aria-label="Select level"></select>
-      </div>
-    </div>
-
-    <div class="menu-section">
-      <div class="menu-section-title">Select Fighter</div>
-      <div class="char-select">
-        <div id="charGrid" class="char-grid" role="listbox" aria-label="Character select">
-          <button class="char-card" data-char="lucy" role="option" aria-selected="true">
-            <div class="char-name">Lucy • 8</div>
-          </button>
-          <button class="char-card" data-char="joey" role="option" aria-selected="false">
-            <div class="char-name">Joey • 6</div>
-          </button>
-          <button class="char-card" data-char="abe" role="option" aria-selected="false">
-            <div class="char-name">Abe • 3</div>
-          </button>
-          <button class="char-card" data-char="leo" role="option" aria-selected="false">
-            <div class="char-name">Leo • 1</div>
-          </button>
+    <div class="menu-scroll">
+      <div class="menu-section">
+        <div class="menu-section-title">Select Level</div>
+        <div id="levelGrid" class="level-grid" aria-label="Level select"></div>
+        <div class="sr-only">
+          <label for="levelSelect">Level</label>
+          <select id="levelSelect" aria-label="Select level"></select>
         </div>
-        <div class="char-preview-wrap">
-          <canvas id="charPreview" width="420" height="300" aria-label="Character portrait"></canvas>
+      </div>
+
+      <div class="menu-section">
+        <div class="menu-section-title">Select Fighter</div>
+        <div class="char-select">
+          <div id="charGrid" class="char-grid" role="listbox" aria-label="Character select">
+            <button class="char-card" data-char="lucy" role="option" aria-selected="true">
+              <div class="char-name">Lucy • 8</div>
+            </button>
+            <button class="char-card" data-char="joey" role="option" aria-selected="false">
+              <div class="char-name">Joey • 6</div>
+            </button>
+            <button class="char-card" data-char="abe" role="option" aria-selected="false">
+              <div class="char-name">Abe • 3</div>
+            </button>
+            <button class="char-card" data-char="leo" role="option" aria-selected="false">
+              <div class="char-name">Leo • 1</div>
+            </button>
+          </div>
+          <div class="char-preview-wrap">
+            <canvas id="charPreview" width="420" height="300" aria-label="Character portrait"></canvas>
+          </div>
         </div>
       </div>
     </div>

--- a/jump-kids/styles.css
+++ b/jump-kids/styles.css
@@ -81,7 +81,8 @@
   #menu{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,0.45); z-index:50; }
   #menu.hidden{ display:none; }
   .menu-card{ width:min(980px, 94vw); background:radial-gradient(ellipse at top, rgba(255,255,255,0.98), rgba(255,255,255,0.94)); border-radius:18px; box-shadow:0 10px 30px rgba(0,0,0,0.25);
-    border:1px solid rgba(0,0,0,0.12); padding:22px; max-height: 90vh; overflow-y: auto; }
+    border:1px solid rgba(0,0,0,0.12); padding:22px; max-height: 90vh; display:flex; flex-direction:column; }
+  .menu-scroll{ flex:1 1 auto; overflow-y:auto; }
   .menu-title{ margin:0 0 14px; font-size:48px; text-align:center; letter-spacing:1.5px; }
   .arcade{ font-family: Impact, Haettenschweiler, 'Arial Black', system-ui, sans-serif; text-shadow: 0 3px 0 rgba(0,0,0,0.25), 0 0 20px rgba(255,183,3,0.5); color:#0b1b2b; }
   .menu-section{ margin:10px 0 18px; }
@@ -106,7 +107,7 @@
   #charGrid:focus-within ~ .char-preview-wrap #charPreview{ opacity:1; }
 
   .menu-start{ width:100%; margin-top:16px; padding:12px 16px; font-weight:700; font-size:16px; border-radius:12px; border:1px solid rgba(0,0,0,0.15);
-    background:linear-gradient(#fff,#eef3f8); box-shadow:0 3px 0 rgba(0,0,0,0.15); }
+    background:linear-gradient(#fff,#eef3f8); box-shadow:0 3px 0 rgba(0,0,0,0.15); flex-shrink:0; }
   .menu-start.big{ font-size:20px; padding:16px 20px; }
   .menu-help{ margin-top:10px; font-size:12px; opacity:0.8; text-align:center; }
 


### PR DESCRIPTION
## Summary
- Ensure Jump Kids start button is visible on mobile and respond to touch
- Wrap menu sections in scrollable container
- Adjust Beamer canvas scaling on mobile so full court fits in view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a241d45e2c832990a68d2ad1ced618