### PR TITLE
Enhance zakkos, treasure boxes and mobile layouts

### DIFF
--- a/beamer/index.html
+++ b/beamer/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, orientation=landscape">
+<meta name="viewport" content="width=device-width, initial-scale=0.5, user-scalable=no, orientation=landscape">
 <title>Beamer</title>
 <link rel="stylesheet" href="style.css">
 </head>

--- a/jump-kids/game.js
+++ b/jump-kids/game.js
@@ -242,7 +242,12 @@ class Hellmonk extends Entity{
   constructor(x,y){ super(x,y,24,24); this.speed=55; this.chargeSpeed=210; this.state='idle'; this.reactCD=0; this.facing=-1; this.jump=-520; }
 }
 class Zakko extends Entity{
-  constructor(x,y){ super(x,y,20,80); this.knocked=false; }
+  constructor(x,y){
+    // Tall dummy enemy; will chase player slowly but avoid walking off ledges
+    super(x,y,20,160);
+    this.knocked=false;
+    this.speed=30;
+  }
 }
 
 function growPlayer(p){
@@ -265,17 +270,18 @@ function findInMap(symbol){ for (let y=0;y<H;y++){ const x=LEVEL[y].indexOf(symb
 function buildWorld(){
   const spawn = findInMap('P');
   const world = { player:new Player(spawn.x*TILE,(spawn.y-1)*TILE), enemies:[], coins:[], blocks:[], goal:null, checkpoint:null, camX:0, state:'play', winT:0, time:0 };
-  let boxAlt = 0;
   for (let y=0;y<H;y++){
     for (let x=0;x<W;x++){
       const c=LEVEL[y][x];
       if (c==='E') world.enemies.push(new Goomba(x*TILE,(y-1)*TILE));
       if (c==='H') world.enemies.push(new Hellmonk(x*TILE,(y-1)*TILE));
-      if (c==='Z'){ const top = groundTopAt(x,y) - 80; world.enemies.push(new Zakko(x*TILE, top)); }
+      if (c==='Z'){ const top = groundTopAt(x,y) - 160; world.enemies.push(new Zakko(x*TILE, top)); }
       if (c==='C') world.coins.push({x:x*TILE+8,y:(y-1)*TILE+8,r:7,taken:false});
       if (c==='[') world.blocks.push({x:x*TILE,y:(y-1)*TILE,w:TILE,h:TILE,type:'q',bounce:0,used:false});
       if (c==='B'){
-        const content = (boxAlt++%2===0) ? {type:'coins',amount:2+Math.floor(Math.random()*3)} : {type:'shamrock'};
+        const content = (Math.random() < 0.5)
+          ? {type:'coins',amount:2+Math.floor(Math.random()*3)}
+          : {type:'shamrock'};
         world.blocks.push({x:x*TILE,y:(y-1)*TILE,w:TILE,h:TILE,type:'mystery',bounce:0,used:false,content});
       }
       if (c==='G'){
@@ -700,7 +706,8 @@ function update(dt){
   if (prevVy < 0){
     for (const b of world.blocks){
       if (b.used) continue;
-      if (p.x < b.x + b.w && p.x + p.w > b.x && prevBottom <= b.y + b.h && p.y >= b.y + b.h - 2){
+      const hit = p.x < b.x + b.w && p.x + p.w > b.x && prevBottom <= b.y + b.h && p.bottom >= b.y + b.h;
+      if (hit){
         b.used = true; b.bounce = 1;
         if (b.content && b.content.type==='coins'){
           p.coins += b.content.amount; HUD.coins.textContent = p.coins; playCoin();
@@ -781,12 +788,23 @@ function update(dt){
         }
       }
     } else if (e instanceof Zakko){
+      // Slowly move toward player if close, but stop before walking off edges
+      const dx = (p.x + p.w/2) - (e.x + e.w/2);
+      const dist = Math.abs(dx);
+      e.vx = 0;
+      if (dist < 240){
+        const dir = Math.sign(dx);
+        const aheadTx = Math.floor(((dir>0? e.right+1 : e.left-1))/TILE);
+        const footTy = Math.floor((e.bottom+1)/TILE)+1;
+        if (isSolid(tileAt(aheadTx, footTy))) e.vx = dir * e.speed;
+      }
+      moveWithCollisions(e, e.vx*dt, 0, true);
       moveWithCollisions(e, 0, e.vy*dt, true);
       if (!e.remove && aabb(p,e)){
         const fromAbove = (p.vy>0) && (p.bottom - e.top < 18);
         if (fromAbove){
           p.vy = -0.55*JUMP_VEL;
-          if (!e.knocked){ e.knocked=true; e.h=40; e.y += 40; }
+          if (!e.knocked){ e.knocked=true; e.h=80; e.y += 80; }
           else e.remove=true;
         } else if (p.invuln<=0){
           if (p.big){ shrinkPlayer(p); p.invuln=1; }
@@ -980,10 +998,18 @@ function drawZakko(x,y,e){
   ctx.save();
   ctx.translate(x,y);
   if (!e.knocked){
+    // Body
     ctx.fillStyle = '#d4a373';
-    ctx.fillRect(4,0,12,e.h);
+    ctx.fillRect(4,40,12,e.h-40);
+    // Feet
     ctx.fillStyle = '#8b5a2b';
     ctx.fillRect(0,e.h-10,20,10);
+    // Head
+    ctx.fillStyle = '#ffddbf';
+    ctx.fillRect(2,0,16,40);
+    // Mop of curly red hair
+    ctx.fillStyle = '#b91c1c';
+    for (let i=-1;i<=3;i++){ ctx.beginPath(); ctx.arc(10 + i*6, -4, 14, 0, Math.PI*2); ctx.fill(); }
   } else {
     ctx.fillStyle = '#d4a373';
     ctx.fillRect(0,e.h-20,20,20);

--- a/jump-kids/styles.css
+++ b/jump-kids/styles.css
@@ -78,7 +78,7 @@
   #help{ position: fixed; right:10px; top:60px; background:rgba(0,0,0,0.55); color:#fff; padding:8px 10px; font-size:12px; border-radius:8px;}
 
   /* Start Menu */
-  #menu{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,0.45); z-index:50; }
+  #menu{ position:fixed; inset:0; display:flex; align-items:flex-start; justify-content:center; background:rgba(0,0,0,0.45); z-index:50; overflow-y:auto; padding-top:20px; }
   #menu.hidden{ display:none; }
   .menu-card{ width:min(980px, 94vw); background:radial-gradient(ellipse at top, rgba(255,255,255,0.98), rgba(255,255,255,0.94)); border-radius:18px; box-shadow:0 10px 30px rgba(0,0,0,0.25);
     border:1px solid rgba(0,0,0,0.12); padding:22px; max-height: 90vh; display:flex; flex-direction:column; }


### PR DESCRIPTION
## Summary
- Double-height zakkos now chase the player cautiously and sport curly red hair.
- Mystery boxes award 2-4 coins or a shamrock when hit from below.
- Allow scrolling on Jump Kids' start menu and zoom out Beamer on mobile.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a246c351ec83298896b47876f31636