### PR TITLE
Add utility tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# ltrgordon.github.io
+
+This repository contains the source for a static personal site. The `beamer` directory hosts a browser game that simulates a pong-style battle with light refraction through a lens.
+
+## Development
+
+The `beamer` game uses a small set of utility functions for lens physics and paddle handicaps. These functions are defined in `beamer/utils.js` so they can be reused both by the game and by automated tests.
+
+### Running Tests
+
+Tests are implemented using Node's built-in `assert` module. To run them:
+
+```bash
+npm test
+```
+
+The test suite exercises the utility functions to ensure lens materials and handicap calculations behave as expected.

--- a/beamer/beamer.js
+++ b/beamer/beamer.js
@@ -85,46 +85,7 @@ function saveConfig(){
   }));
 }
 
-// Lens material properties
-function getLensRefractiveIndex(material) {
-  const indices = {
-    'glass': 1.7,
-    'silicon': 2.5,
-    'germanium': 4.0
-  };
-  return indices[material] || 1.7;
-}
-
-function getLensMaterialDisplayName(material) {
-  const names = {
-    'glass': 'Glass (n=1.7)',
-    'silicon': 'Silicon (n=2.5)',
-    'germanium': 'Germanium (n=4.0)'
-  };
-  return names[material] || 'Glass (n=1.7)';
-}
-
-// Handicap system
-function getHandicapHeight(handicap) {
-  const baseHeight = 96;
-  const heights = {
-    'small': Math.floor(baseHeight * 0.7),
-    'standard': baseHeight,
-    'large': Math.floor(baseHeight * 1.3),
-    'extra_large': Math.floor(baseHeight * 1.6)
-  };
-  return heights[handicap] || baseHeight;
-}
-
-function getHandicapDisplayName(handicap) {
-  const names = {
-    'small': 'Small',
-    'standard': 'Standard',
-    'large': 'Large',
-    'extra_large': 'Extra Large'
-  };
-  return names[handicap] || 'Standard';
-}
+// Utility functions moved to utils.js and loaded separately
 
 // Audio
 const AudioCtx = window.AudioContext || window.webkitAudioContext;

--- a/beamer/index.html
+++ b/beamer/index.html
@@ -57,6 +57,7 @@
   <div id="gameover" class="panel hidden"><h1 id="winner"></h1><p>[Enter] Play Again &nbsp; [Esc] Menu</p></div>
 </div>
 
+<script src="utils.js"></script>
 <script src="beamer.js"></script>
 </body>
 </html>

--- a/beamer/utils.js
+++ b/beamer/utils.js
@@ -1,0 +1,53 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    Object.assign(root, factory());
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+  function getLensRefractiveIndex(material) {
+    const indices = {
+      glass: 1.7,
+      silicon: 2.5,
+      germanium: 4.0
+    };
+    return indices[material] || 1.7;
+  }
+
+  function getLensMaterialDisplayName(material) {
+    const names = {
+      glass: 'Glass (n=1.7)',
+      silicon: 'Silicon (n=2.5)',
+      germanium: 'Germanium (n=4.0)'
+    };
+    return names[material] || 'Glass (n=1.7)';
+  }
+
+  function getHandicapHeight(handicap) {
+    const baseHeight = 96;
+    const heights = {
+      small: Math.floor(baseHeight * 0.7),
+      standard: baseHeight,
+      large: Math.floor(baseHeight * 1.3),
+      extra_large: Math.floor(baseHeight * 1.6)
+    };
+    return heights[handicap] || baseHeight;
+  }
+
+  function getHandicapDisplayName(handicap) {
+    const names = {
+      small: 'Small',
+      standard: 'Standard',
+      large: 'Large',
+      extra_large: 'Extra Large'
+    };
+    return names[handicap] || 'Standard';
+  }
+
+  return {
+    getLensRefractiveIndex,
+    getLensMaterialDisplayName,
+    getHandicapHeight,
+    getHandicapDisplayName
+  };
+}));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ltrgordon.github.io",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/utils.test.js"
+  }
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const {
+  getLensRefractiveIndex,
+  getLensMaterialDisplayName,
+  getHandicapHeight,
+  getHandicapDisplayName
+} = require('../beamer/utils.js');
+
+// Refractive index tests
+assert.strictEqual(getLensRefractiveIndex('glass'), 1.7);
+assert.strictEqual(getLensRefractiveIndex('silicon'), 2.5);
+assert.strictEqual(getLensRefractiveIndex('germanium'), 4.0);
+assert.strictEqual(getLensRefractiveIndex('unknown'), 1.7);
+
+// Material display names
+assert.strictEqual(getLensMaterialDisplayName('silicon'), 'Silicon (n=2.5)');
+assert.strictEqual(getLensMaterialDisplayName('plastic'), 'Glass (n=1.7)');
+
+// Handicap heights
+assert.strictEqual(getHandicapHeight('small'), Math.floor(96 * 0.7));
+assert.strictEqual(getHandicapHeight('standard'), 96);
+assert.strictEqual(getHandicapHeight('large'), Math.floor(96 * 1.3));
+assert.strictEqual(getHandicapHeight('extra_large'), Math.floor(96 * 1.6));
+assert.strictEqual(getHandicapHeight('unknown'), 96);
+
+// Handicap display names
+assert.strictEqual(getHandicapDisplayName('extra_large'), 'Extra Large');
+assert.strictEqual(getHandicapDisplayName('unknown'), 'Standard');
+
+console.log('All utility tests passed.');


### PR DESCRIPTION
## Summary
- extract shared lens and handicap helpers into `beamer/utils.js`
- add Node-based tests for utility functions
- document project layout and test usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24b24bf448329888ae818ac8dcba4