### PR TITLE
Fix mobile layouts for Jump Kids and Beamer

### DIFF
--- a/beamer/index.html
+++ b/beamer/index.html
@@ -2,22 +2,24 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=0.5, user-scalable=no, orientation=landscape">
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, orientation=landscape">
 <title>Beamer</title>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<canvas id="game" width="960" height="640"></canvas>
+<div id="game-container">
+  <canvas id="game" width="960" height="640"></canvas>
 
-<!-- Mobile Controls -->
-<div id="mobile-controls">
-  <div class="mobile-paddle" id="mobile-left">
-    <button class="paddle-btn" id="left-up" aria-label="Left paddle up">▲</button>
-    <button class="paddle-btn" id="left-down" aria-label="Left paddle down">▼</button>
-  </div>
-  <div class="mobile-paddle" id="mobile-right">
-    <button class="paddle-btn" id="right-up" aria-label="Right paddle up">▲</button>
-    <button class="paddle-btn" id="right-down" aria-label="Right paddle down">▼</button>
+  <!-- Mobile Controls -->
+  <div id="mobile-controls">
+    <div class="mobile-paddle" id="mobile-left">
+      <button class="paddle-btn" id="left-up" aria-label="Left paddle up">▲</button>
+      <button class="paddle-btn" id="left-down" aria-label="Left paddle down">▼</button>
+    </div>
+    <div class="mobile-paddle" id="mobile-right">
+      <button class="paddle-btn" id="right-up" aria-label="Right paddle up">▲</button>
+      <button class="paddle-btn" id="right-down" aria-label="Right paddle down">▼</button>
+    </div>
   </div>
 </div>
 

--- a/beamer/style.css
+++ b/beamer/style.css
@@ -6,23 +6,29 @@ body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
+#game-container {
+  position: relative;
+  width: 960px;
+  height: 640px;
+  margin: 0 auto;
+  max-width: 100vw;
+  max-height: 100vh;
+}
+
 #game {
   display: block;
-  margin: 0 auto;
   background: #0b1221;
   image-rendering: pixelated;
   image-rendering: -moz-crisp-edges;
   image-rendering: crisp-edges;
-  max-width: 100vw;
-  max-height: 100vh;
-  width: 960px;
-  height: 640px;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
 }
 
 /* Mobile Controls */
 #mobile-controls {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -54,7 +60,7 @@ body {
   height: 60px;
   border-radius: 50%;
   border: 2px solid #06b6d4;
-  background: rgba(6, 182, 212, 0.2);
+  background: rgba(6, 182, 212, 0.3);
   color: #06b6d4;
   font-size: 24px;
   font-weight: bold;
@@ -65,6 +71,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 0.8;
 }
 
 .paddle-btn:active {
@@ -81,10 +88,16 @@ body {
 
 /* Mobile scaling adjustments */
 @media (max-width: 1023px) {
-  #game {
+  #game-container {
+    width: 100vw;
     height: 100vh;
-    width: auto;
+  }
+
+  #game {
+    width: 100%;
+    height: 100%;
     max-width: 100vw;
+    max-height: 100vh;
   }
 
   body {
@@ -138,7 +151,7 @@ body {
   #landscape-notice {
     display: flex;
   }
-  #game, #overlay, #mobile-controls {
+  #game-container, #overlay, #mobile-controls {
     display: none;
   }
 }

--- a/jump-kids/styles.css
+++ b/jump-kids/styles.css
@@ -115,6 +115,7 @@
 
   /* Mobile responsive adjustments */
   @media (max-width: 768px) {
+    #wrap{ transform: scale(0.65); transform-origin: top center; }
     .menu-title{ font-size:36px; }
     .char-select{ grid-template-columns: 1fr; gap:12px; }
     .char-preview-wrap{ height: 200px; }


### PR DESCRIPTION
## Summary
- Scale Jump Kids interface on small screens so player and control buttons stay visible
- Ensure Beamer's paddle controls display on mobile by adjusting viewport and overlaying semi-transparent buttons within a new game container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24ecd07ec83298d3bd632844e6b2a