### PR TITLE
Adjust mobile zoom for beamer and jump-kids

### DIFF
--- a/beamer/style.css
+++ b/beamer/style.css
@@ -89,15 +89,13 @@ body {
 /* Mobile scaling adjustments */
 @media (max-width: 1023px) {
   #game-container {
-    width: 100vw;
-    height: 100vh;
+    width: 480px;
+    height: 320px;
   }
 
   #game {
     width: 100%;
     height: 100%;
-    max-width: 100vw;
-    max-height: 100vh;
   }
 
   body {

--- a/jump-kids/styles.css
+++ b/jump-kids/styles.css
@@ -115,7 +115,7 @@
 
   /* Mobile responsive adjustments */
   @media (max-width: 768px) {
-    #wrap{ transform: scale(0.65); transform-origin: top center; }
+    #wrap{ transform: scale(0.5); transform-origin: top left; }
     .menu-title{ font-size:36px; }
     .char-select{ grid-template-columns: 1fr; gap:12px; }
     .char-preview-wrap{ height: 200px; }
@@ -126,5 +126,5 @@
     #hud{ gap:12px; font-size:14px; }
     footer{ height:60px; gap:12px; }
     .btn{ width:56px; height:56px; font-size:16px; }
-    canvas{ width: 100vw; max-width: none; height: calc(100vh - 118px); max-height: none; }
+    canvas{ width: 960px; height: 540px; }
   }


### PR DESCRIPTION
## Summary
- Scale beamer game container down on mobile so entire court fits
- Reduce jump-kids mobile scale and use fixed canvas size to keep player on screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a25b14e9548329a7c51e01fd2879e5