### PR TITLE
Show desktop versions of games on all devices

### DIFF
--- a/beamer/beamer.js
+++ b/beamer/beamer.js
@@ -2,44 +2,13 @@
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 
-// Dynamic canvas sizing for mobile
-function resizeCanvas() {
-  const isMobile = window.innerWidth <= 1023;
-  const dpr = window.devicePixelRatio || 1;
-  
-  if (isMobile) {
-    // On mobile, use full viewport
-    const displayWidth = window.innerWidth;
-    const displayHeight = window.innerHeight;
-    
-    canvas.width = displayWidth * dpr;
-    canvas.height = displayHeight * dpr;
-    
-    canvas.style.width = displayWidth + 'px';
-    canvas.style.height = displayHeight + 'px';
-    
-    ctx.scale(dpr, dpr);
-  } else {
-    // On desktop, use fixed size
-    const displayWidth = 960;
-    const displayHeight = 640;
-    
-    canvas.width = displayWidth * dpr;
-    canvas.height = displayHeight * dpr;
-    
-    canvas.style.width = displayWidth + 'px';
-    canvas.style.height = displayHeight + 'px';
-    
-    ctx.scale(dpr, dpr);
-  }
-}
-
-// Initial resize and listen for orientation changes
-resizeCanvas();
-window.addEventListener('resize', resizeCanvas);
-window.addEventListener('orientationchange', () => {
-  setTimeout(resizeCanvas, 100);
-});
+// Fixed desktop-sized canvas
+const dpr = window.devicePixelRatio || 1;
+canvas.width = 960 * dpr;
+canvas.height = 640 * dpr;
+canvas.style.width = '960px';
+canvas.style.height = '640px';
+ctx.scale(dpr, dpr);
 
 const overlay = document.getElementById('overlay');
 const menuPanel = document.getElementById('menu');

--- a/beamer/index.html
+++ b/beamer/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, orientation=landscape">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Beamer</title>
 <link rel="stylesheet" href="style.css">
 </head>
@@ -20,15 +20,6 @@
       <button class="paddle-btn" id="right-up" aria-label="Right paddle up">▲</button>
       <button class="paddle-btn" id="right-down" aria-label="Right paddle down">▼</button>
     </div>
-  </div>
-</div>
-
-<!-- Landscape Orientation Notice -->
-<div id="landscape-notice">
-  <div class="notice-content">
-    <div class="rotate-icon">📱</div>
-    <h2>Please Rotate Your Device</h2>
-    <p>This game requires landscape orientation for the best experience.</p>
   </div>
 </div>
 

--- a/beamer/style.css
+++ b/beamer/style.css
@@ -86,73 +86,6 @@ body {
   }
 }
 
-/* Mobile scaling adjustments */
-@media (max-width: 1023px) {
-  #game-container {
-    width: 480px;
-    height: 320px;
-  }
-
-  #game {
-    width: 100%;
-    height: 100%;
-  }
-
-  body {
-    overflow: hidden;
-  }
-}
-
-/* Landscape Notice */
-#landscape-notice {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: #0b1221;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-.notice-content {
-  text-align: center;
-  padding: 20px;
-  color: #e5e7eb;
-}
-
-.rotate-icon {
-  font-size: 64px;
-  margin-bottom: 20px;
-  animation: rotate 2s ease-in-out infinite alternate;
-}
-
-@keyframes rotate {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(90deg); }
-}
-
-.notice-content h2 {
-  margin: 0 0 10px;
-  color: #06b6d4;
-}
-
-.notice-content p {
-  margin: 0;
-  opacity: 0.8;
-}
-
-/* Show landscape notice only on mobile portrait */
-@media (max-width: 1023px) and (orientation: portrait) {
-  #landscape-notice {
-    display: flex;
-  }
-  #game-container, #overlay, #mobile-controls {
-    display: none;
-  }
-}
 
 #overlay {
   position: absolute;
@@ -228,18 +161,3 @@ h1, h2 {
   }
 }
 
-/* Mobile-responsive panel text */
-@media (max-width: 768px) {
-  .panel {
-    padding: 16px 24px;
-    font-size: 14px;
-  }
-  
-  .panel h1 {
-    font-size: 24px;
-  }
-  
-  .panel h2 {
-    font-size: 20px;
-  }
-}

--- a/jump-kids/game.js
+++ b/jump-kids/game.js
@@ -134,22 +134,19 @@ function updateCharSelection(id, previewOnly=false){
   }
 }
 if (charGrid){
-  const isMobile = () => window.innerWidth <= 1023;
   const togglePreview = (show)=>{ if (charPreviewWrap) charPreviewWrap.classList.toggle('visible', !!show); };
   
   charGrid.addEventListener('mouseover', (e)=>{ const btn = e.target.closest('.char-card'); if (btn){ updateCharSelection(btn.dataset.char, true); } });
   charGrid.addEventListener('focusin', (e)=>{ const btn = e.target.closest('.char-card'); if (btn){ updateCharSelection(btn.dataset.char, true); } });
   charGrid.addEventListener('click', (e)=>{ const btn = e.target.closest('.char-card'); if (btn) updateCharSelection(btn.dataset.char, false); });
   
-  // Hide portrait logic: only hide on mobile when leaving grid/focus
-  charGrid.addEventListener('mouseout', (e)=>{ 
-    if (isMobile() && !charGrid.contains(e.relatedTarget)) togglePreview(false); 
+  // Hide portrait when leaving the grid or focus moves elsewhere
+  charGrid.addEventListener('mouseout', (e)=>{
+    if (!charGrid.contains(e.relatedTarget)) togglePreview(false);
   });
-  charGrid.addEventListener('focusout', ()=>{ 
-    if (isMobile()) {
-      const anyFocused = !!charGrid.querySelector('.char-card:focus'); 
-      if (!anyFocused) togglePreview(false); 
-    }
+  charGrid.addEventListener('focusout', ()=>{
+    const anyFocused = !!charGrid.querySelector('.char-card:focus');
+    if (!anyFocused) togglePreview(false);
   });
 }
 

--- a/jump-kids/index.html
+++ b/jump-kids/index.html
@@ -2,20 +2,11 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, orientation=landscape"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Jump Kids</title>
 <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-<!-- Landscape Orientation Notice -->
-<div id="landscape-notice">
-  <div class="notice-content">
-    <div class="rotate-icon">📱</div>
-    <h2>Please Rotate Your Device</h2>
-    <p>This game requires landscape orientation for the best experience.</p>
-  </div>
-</div>
-
 <div id="wrap">
   <header>
     <div class="title">Super Mario Bros — MVP</div>

--- a/jump-kids/styles.css
+++ b/jump-kids/styles.css
@@ -5,57 +5,6 @@
   html,body{ margin:0; padding:0; height:100%; background:linear-gradient(180deg,var(--bg2),var(--bg1) 60%, #9bd4ff);
     color:var(--ui); font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; overflow:hidden;}
 
-  /* Landscape Notice */
-  #landscape-notice {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(180deg,var(--bg2),var(--bg1) 60%, #9bd4ff);
-    display: none;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-  }
-
-  .notice-content {
-    text-align: center;
-    padding: 20px;
-    color: var(--ui);
-  }
-
-  .rotate-icon {
-    font-size: 64px;
-    margin-bottom: 20px;
-    animation: rotate 2s ease-in-out infinite alternate;
-  }
-
-  @keyframes rotate {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(90deg); }
-  }
-
-  .notice-content h2 {
-    margin: 0 0 10px;
-    color: var(--ui);
-    font-weight: 800;
-  }
-
-  .notice-content p {
-    margin: 0;
-    opacity: 0.8;
-  }
-
-  /* Show landscape notice only on mobile portrait */
-  @media (max-width: 1023px) and (orientation: portrait) {
-    #landscape-notice {
-      display: flex;
-    }
-    #wrap, #menu, #help {
-      display: none;
-    }
-  }
 
   #wrap{ position:fixed; inset:0; display:grid; grid-template-rows:auto 1fr auto;}
   header{ padding:8px 12px; display:flex; gap:16px; align-items:center; justify-content:space-between;
@@ -113,18 +62,3 @@
 
   .sr-only{ position:absolute; left:-9999px; width:1px; height:1px; overflow:hidden; }
 
-  /* Mobile responsive adjustments */
-  @media (max-width: 768px) {
-    #wrap{ transform: scale(0.5); transform-origin: top left; }
-    .menu-title{ font-size:36px; }
-    .char-select{ grid-template-columns: 1fr; gap:12px; }
-    .char-preview-wrap{ height: 200px; }
-    .level-tile{ padding:20px 14px; font-size:20px; }
-    .char-card{ padding:12px; }
-    .char-name{ font-size:18px; }
-    header{ padding:6px 8px; gap:12px; }
-    #hud{ gap:12px; font-size:14px; }
-    footer{ height:60px; gap:12px; }
-    .btn{ width:56px; height:56px; font-size:16px; }
-    canvas{ width: 960px; height: 540px; }
-  }


### PR DESCRIPTION
## Summary
- Remove mobile-only orientation logic from Jump Kids and Beamer
- Always render desktop layout while keeping on-screen touch controls for mobile
- Simplify canvas sizing for Beamer to fixed desktop dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27feb2db4832983474878cd845c92