### PR TITLE
Fix vertical collision bug and add improvement recommendations

### DIFF
--- a/improvements.md
+++ b/improvements.md
@@ -1,0 +1,29 @@
+# Improvement Recommendations for Jump Kids
+
+This document lists suggestions to enhance the game's functionality and maintainability so that future development—especially by AI agents—is smoother.
+
+## Functionality
+- **Add game state persistence**: Save player progress, coin count, and unlocked levels to localStorage so players can resume sessions.
+- **Improve accessibility**: Include focus indicators, ARIA roles for dynamic elements, and alternative control schemes for players with limited mobility.
+- **Responsive scaling**: Allow configurable canvas resolution and aspect ratio so the game can adapt to different screen sizes more effectively.
+
+## Formatting & Style
+- **Adopt a consistent code style**: Use an automated formatter (e.g., Prettier) and a linter to enforce uniform spacing, quoting, and semicolon usage.
+- **Split long files**: Break `game.js` into smaller modules (entities, rendering, physics, input) to keep files under a few hundred lines.
+
+## Modularity & Structure
+- **Use ES modules**: Replace global variables with module imports/exports to reduce implicit dependencies.
+- **Entity system**: Formalize a base entity class with update/render hooks to simplify addition of new enemies or items.
+- **Configuration layer**: Centralize tunable constants (physics, controls, level settings) into a configuration module that can be easily tweaked or overridden.
+
+## Maintenance & Testing
+- **Unit tests for core mechanics**: Add tests for collision detection, special moves, and item behavior to catch regressions early.
+- **Automated build and lint scripts**: Integrate npm scripts or a CI pipeline to run tests and formatting checks on every commit.
+- **Documentation**: Expand inline comments and provide a developer guide that describes the game loop, level format, and extension points.
+
+## Ease of Expansion
+- **Plugin-like level loader**: Support dynamically loading multiple level files and define a manifest that lists available levels.
+- **Asset pipeline**: Separate art and sound assets from logic and provide a structured folder hierarchy for easier replacement or addition.
+- **Parameter-driven enemies**: Allow enemy behaviors to be configured via JSON so new variations can be introduced without modifying code.
+
+Implementing these improvements will make the codebase easier to extend and maintain, especially when contributors include AI agents that benefit from clear structure and automated checks.

--- a/jump-kids/game.js
+++ b/jump-kids/game.js
@@ -540,7 +540,7 @@ function moveWithCollisions(ent, dx, dy, isEnemy=false){
         if (rectOverlap(ent.x,ent.y,ent.w,ent.h,tileRect.x,tileRect.y,tileRect.w,tileRect.h)){
           if (dy>0) ent.y = tileRect.y - ent.h - 0.01; // restore landing snap above tile
           else ent.y = tileRect.y + tileRect.h;
-          ent.vy = 10;
+          ent.vy = 0;
           onGround=true;
         }
       }


### PR DESCRIPTION
## Summary
- Correct vertical velocity reset after tile collisions so entities stop bouncing
- Document future improvement ideas for Jump Kids in `improvements.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a40a8d5890832992e7ea9cd7caea7f