### PR TITLE
refactor: modularize jump kids

### DIFF
--- a/jump-kids/README.md
+++ b/jump-kids/README.md
@@ -1,6 +1,6 @@
 # Jump Kids
 
-A small, modular browser platformer inspired by classic side‑scrollers. This version factors the UI (HTML/CSS) and gameplay (JS) into separate files for easier iteration and reuse.
+A small, modular browser platformer inspired by classic side‑scrollers. This version factors the UI (HTML/CSS) and gameplay (JS) into separate files for easier iteration and reuse.  Gameplay code now uses ES modules for clearer dependencies and easier maintenance.
 
 ## Overview
 - Canvas‑based runner/platformer with tile collisions and simple entities.
@@ -78,9 +78,13 @@ Legend (selected):
 Tiles are 32×32 px. World Y↔tile mapping uses a consistent “(ty-1)*TILE” convention for collision and rendering.
 
 ## Code Structure
+
+- `config.js` – Centralized constants for physics, controls, and colors.
+- `entity.js` – Base `Entity` class with update/render hooks.
+- `special-moves.js` – Character abilities built via a factory and imported by the main game.
 - `index.html` – Layout, HUD, canvas, on‑screen buttons; loads `game.js` and `styles.css`.
 - `styles.css` – Light, responsive UI and controls styling.
-- `game.js` – Gameplay modules:
+- `game.js` – Gameplay module importing configuration, entities, and special moves:
   - Constants and helpers (DPI fit, ellipse fallback, time formatting)
   - Level definition (BASE/EXT) and tile helpers (`tileAt`, `isSolid`); optional JSON loader (`level1.json`)
   - Surface finding helpers to anchor poles (`surfaceTopAt`, `groundTopAt`)

--- a/jump-kids/config.js
+++ b/jump-kids/config.js
@@ -1,0 +1,13 @@
+export const TILE = 32;
+export const GRAVITY = 1800;      // px/s^2
+export const MOVE_ACC = 2600;     // px/s^2
+export const MOVE_MAX = 230;      // px/s
+export const FRICTION = 1800;     // px/s^2
+export const JUMP_VEL = 620;      // px/s
+export const CAM_MARGIN_X = 340;  // camera lead
+export const EPSY = 0.75;         // vertical snap epsilon (px) to stop jitter
+export const COYOTE_TIME = 0.10;  // seconds after walking off ledge where jump still works
+export const JUMP_BUFFER = 0.12;  // seconds to buffer jump pressed slightly before landing
+
+// Canvas colors
+export const COL = { ground:'#7c4a1f', grass:'#49a020', brick:'#b85a35', coin:'#f2c14e' };

--- a/jump-kids/entity.js
+++ b/jump-kids/entity.js
@@ -1,0 +1,15 @@
+export class Entity {
+  constructor(x, y, w, h) {
+    this.x = x; this.y = y; this.w = w; this.h = h;
+    this.vx = 0; this.vy = 0;
+    this.dead = false; this.remove = false; this.grounded = false;
+  }
+  get left() { return this.x; }
+  get right() { return this.x + this.w; }
+  get top() { return this.y; }
+  get bottom() { return this.y + this.h; }
+  // Update hook: override in subclasses
+  update(dt, world) {}
+  // Render hook: override in subclasses
+  render(ctx, camX) {}
+}

--- a/jump-kids/game.js
+++ b/jump-kids/game.js
@@ -1,4 +1,8 @@
 // ======= Core constants & helpers =======
+import {TILE, GRAVITY, MOVE_ACC, MOVE_MAX, FRICTION, JUMP_VEL, CAM_MARGIN_X, EPSY, COYOTE_TIME, JUMP_BUFFER, COL} from './config.js';
+import { Entity } from './entity.js';
+import { createSpecialMoves } from './special-moves.js';
+
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 // Menu elements
@@ -31,18 +35,6 @@ function ellipsePath(x,y,rx,ry, ctxArg){
 
 const HUD = { coins:document.getElementById('coins'), lives:document.getElementById('lives'), world:document.getElementById('world'), msg:document.getElementById('msg') };
 
-const TILE = 32;
-const GRAVITY = 1800;      // px/s^2
-const MOVE_ACC = 2600;     // px/s^2
-const MOVE_MAX = 230;      // px/s
-const FRICTION = 1800;     // px/s^2
-const JUMP_VEL = 620;      // px/s
-const CAM_MARGIN_X = 340;  // camera lead
-const EPSY = 0.75;         // vertical snap epsilon (px) to stop jitter
-// New: jump feel helpers
-const COYOTE_TIME = 0.10;  // seconds after walking off ledge where jump still works
-const JUMP_BUFFER = 0.12;  // seconds to buffer jump pressed slightly before landing
-
 // Simple SFX (coin via asset, others via tiny beeps); unlock on first input
 let audioReady = false;
 let audioCtx = null;
@@ -66,9 +58,6 @@ function playShamrock(){
   playBeep(520,0.1,0.1);
   setTimeout(()=>playBeep(760,0.12,0.1),100);
 }
-
-// Canvas colors (avoid CSS var() in canvas for broader browser support)
-const COL = { ground:'#7c4a1f', grass:'#49a020', brick:'#b85a35', coin:'#f2c14e' };
 
 // ===== Character portraits (menu) =====
 function drawPortrait(id){
@@ -226,11 +215,9 @@ function surfaceTopAt(tx, startTy){
   }
 }
 
+let SPECIAL_MOVES = createSpecialMoves({W, H, tileAt, isSolid, groundTopAt});
+
 // Entities
-class Entity{
-  constructor(x,y,w,h){ this.x=x; this.y=y; this.w=w; this.h=h; this.vx=0; this.vy=0; this.dead=false; this.remove=false; this.grounded=false; }
-  get left(){ return this.x; } get right(){ return this.x+this.w; } get top(){ return this.y; } get bottom(){ return this.y+this.h; }
-}
 class Player extends Entity{
   constructor(x,y){
     super(x,y,20,28);
@@ -430,7 +417,7 @@ async function startFromMenu(){
     if (resp.ok){
       const data = await resp.json();
       const newLevel = buildLevelFromArrays(data.base||[], data.ext||[]);
-      if (newLevel && newLevel.length){ LEVEL = newLevel; H = LEVEL.length; W = LEVEL[0].length; }
+      if (newLevel && newLevel.length){ LEVEL = newLevel; H = LEVEL.length; W = LEVEL[0].length; SPECIAL_MOVES = createSpecialMoves({W,H,tileAt,isSolid,groundTopAt}); }
     }
   }catch{}
   resetGame();
@@ -1488,7 +1475,7 @@ document.addEventListener('DOMContentLoaded', async ()=>{
   updateCharSelection(selectedChar || 'lucy', false);
   try{
     const resp = await fetch('level1.json');
-    if (resp.ok){ const data = await resp.json(); const newLevel = buildLevelFromArrays(data.base||[], data.ext||[]); if (newLevel && newLevel.length){ LEVEL = newLevel; H = LEVEL.length; W = LEVEL[0].length; } }
+    if (resp.ok){ const data = await resp.json(); const newLevel = buildLevelFromArrays(data.base||[], data.ext||[]); if (newLevel && newLevel.length){ LEVEL = newLevel; H = LEVEL.length; W = LEVEL[0].length; SPECIAL_MOVES = createSpecialMoves({W,H,tileAt,isSolid,groundTopAt}); } }
   }catch{}
   // Show menu by default
   if (menuEl) menuEl.classList.remove('hidden');

--- a/jump-kids/index.html
+++ b/jump-kids/index.html
@@ -74,8 +74,7 @@
 
 <div id="help">Keyboard: ← → move, D dash, Space/Z jump, S for S1 and F for S2. Mobile: use buttons.</div>
 
-<script src="special-moves.js"></script>
-<script src="game.js"></script>
+<script type="module" src="game.js"></script>
 
 <!-- Notes:
 - Extended level length and added higher platforms, coins, Goombas, and Hellmonks in the second half.

--- a/jump-kids/special-moves.js
+++ b/jump-kids/special-moves.js
@@ -1,5 +1,10 @@
-// Special moves for each character
-const SPECIAL_MOVES = {
+import { JUMP_VEL, TILE } from './config.js';
+
+// Build the special moves object given core helpers.
+// `utils` should provide tileAt/isSolid/groundTopAt along with level dimensions.
+export function createSpecialMoves(utils){
+  const { W, H, tileAt, isSolid, groundTopAt } = utils;
+  return {
   lucy: {
     s1(p){
       if(!p.grounded) return;
@@ -121,4 +126,5 @@ const SPECIAL_MOVES = {
       p.vx = 0; p.vy = 0; p.grounded = true;
     }
   }
-};
+  };
+}


### PR DESCRIPTION
## Summary
- convert Jump Kids to ES modules and add central config layer
- introduce reusable Entity base class with update/render hooks
- wire special move factory and update documentation for new modular structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4a6a3afec832991e02be992d2744c