### PR TITLE
Fix background hills and enemy placement in jump-kids

### DIFF
--- a/jump-kids/entities.js
+++ b/jump-kids/entities.js
@@ -211,7 +211,9 @@ export function buildWorld(){
             Object.assign(ent, cfg.params);
             if ('speed' in cfg.params && 'vx' in ent){ ent.vx = (ent.vx<0?-1:1) * ent.speed; }
           }
-          if (cfg.class === 'Zakko'){ ent.y = groundTopAt(x,y) - ent.h; }
+          if (!(ent instanceof Bird) && !(ent instanceof Ghost)){
+            ent.y = groundTopAt(x,y) - ent.h;
+          }
           world.enemies.push(ent);
         }
       }

--- a/jump-kids/rendering.js
+++ b/jump-kids/rendering.js
@@ -44,28 +44,6 @@ function drawHills(camX){
   ctx.restore();
 }
 
-function drawCave(camX){
-  const w = canvas.width / (window.devicePixelRatio||1);
-  const h = canvas.height / (window.devicePixelRatio||1);
-  ctx.save();
-  const grd = ctx.createLinearGradient(0,0,0,h);
-  grd.addColorStop(0,'#222');
-  grd.addColorStop(1,'#000');
-  ctx.fillStyle = grd;
-  ctx.fillRect(0,0,w,h);
-  ctx.fillStyle = '#111';
-  for(let i=0;i<6;i++){
-    const x = ((i*160 - camX*0.1) % (w+180)) - 90;
-    ctx.beginPath();
-    ctx.moveTo(x,0);
-    ctx.lineTo(x+40,0);
-    ctx.lineTo(x+20,40);
-    ctx.closePath();
-    ctx.fill();
-  }
-  ctx.restore();
-}
-
 // Tile draw helpers -------------------------------------------------------
 function drawGround(x,y){
   ctx.fillStyle = COL.ground; ctx.fillRect(x,y,TILE,TILE);
@@ -424,12 +402,7 @@ function drawPauseOverlay(){
 export function draw(world){
   const camX = world.camX|0;
   ctx.clearRect(0,0,canvas.width,canvas.height);
-  const underground = world.player && world.player.y >= 12*TILE;
-  if (underground){
-    drawCave(camX);
-  } else {
-    drawClouds(camX);
-  }
+  drawClouds(camX);
   drawHills(camX);
   for (let y=0;y<H;y++){
     for (let x=0; x<W; x++){


### PR DESCRIPTION
## Summary
- Keep background hills visible at all vertical positions
- Spawn non-flying enemies on the nearest ground tile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5e7ba30588329a2fc3d0a85bdf019