### PR TITLE
Add cartwheel, punch, and bubble abilities to Jump Kids

### DIFF
--- a/jump-kids/README.md
+++ b/jump-kids/README.md
@@ -47,10 +47,10 @@ A small, modular browser platformer inspired by classic side‑scrollers. This v
 - DPI aware canvas sizing; mobile controls; no tile culling to simplify rendering.
 
 ## Characters & Special Moves
-- **Lucy** – S1 high back‑flip jump reaching 1.5× normal height; S2 cartwheel that pushes enemies backward.
+- **Lucy** – S1 high back‑flip jump reaching 1.5× normal height; S2 spinning cartwheel forward that knocks back enemies in her path.
 - **Joey** – S1 invisibility for 10 seconds so sight‑based enemies ignore him; S2 ninja spin dash that knocks down foes.
-- **Abe** – S1 ground smash that sends a shockwave staggering nearby enemies; S2 running punch that knocks down anything in his path.
-- **Leo** – No special moves. Jumps half as high, is invincible to enemies, and floats out of pits instead of falling.
+- **Abe** – S1 ground smash that sends a shockwave staggering nearby enemies; S2 running punch that knocks back enemies with gloves held out front.
+- **Leo** – Hold jump for 3 s to form a bubble and float upward until released; jumps half as high, is invincible to enemies, and floats out of pits instead of falling.
 
 ## Tile/Map Encoding
 The level is an ASCII grid split across two arrays in `game.js`:

--- a/jump-kids/input.js
+++ b/jump-kids/input.js
@@ -47,10 +47,14 @@ function bufferJump(){
 }
 function triggerSpecial(which){
   if (!worldRef || !worldRef.player || !specialMoves) return;
-  const ability = specialMoves[worldRef.player.charId];
+  const p = worldRef.player;
+  const ability = specialMoves[p.charId];
   if (!ability) return;
-  if (which==='s1' && ability.s1) ability.s1(worldRef.player, worldRef);
-  if (which==='s2' && ability.s2) ability.s2(worldRef.player, worldRef);
+  if (p.charId==='leo' && p.action==='bubble'){
+    p.action=null; p.lockControls=false; p.bubbleHold=0; return;
+  }
+  if (which==='s1' && ability.s1) ability.s1(p, worldRef);
+  if (which==='s2' && ability.s2) ability.s2(p, worldRef);
 }
 
 export function initInput(){

--- a/jump-kids/physics.js
+++ b/jump-kids/physics.js
@@ -136,7 +136,7 @@ function handleSpecialCollision(p,e,specialMoves){
 export function update(world, keys, HUD, dt, resetGame, specialMoves){
   const p = world.player;
   const ability = specialMoves[p.charId];
-  if (ability && ability.update) ability.update(p, dt, world);
+  if (ability && ability.update) ability.update(p, dt, world, keys);
   for (const b of world.blocks){ if (b.bounce>0) b.bounce = Math.max(0, b.bounce - dt*4); }
   if (world.state === 'pause') return;
   if (world.state !== 'win' && world.state !== 'gameover') world.time += dt;

--- a/jump-kids/rendering.js
+++ b/jump-kids/rendering.js
@@ -213,6 +213,7 @@ function drawPlayer(x,y,p){
   ctx.translate(0, -p.h/2);
   if (p.action==='flip') ctx.rotate(p.flip||0);
   if (p.action==='spinJump') ctx.rotate(p.spinRotation||0);
+  if (p.action==='cartwheel') ctx.rotate(p.cartRot||0);
   ctx.translate(-p.w/2, -p.h/2);
   if (p.rainbow>0){
     const colors=['#ff0000','#ffa500','#ffff00','#00ff00','#0000ff','#4b0082','#ee82ee'];
@@ -268,8 +269,13 @@ function drawPlayer(x,y,p){
     ctx.fillStyle=head; ctx.fillRect(-1,0,p.w+2,8);
     ctx.fillStyle=accent; ctx.fillRect(0,2,p.w,2);
   } else if(id==='abe'){
-    ctx.fillStyle=head; ctx.fillRect(-3,bodyTop+4,6,6); ctx.fillRect(p.w-3,bodyTop+4,6,6);
-    ctx.strokeStyle=accent; ctx.lineWidth=1; ctx.strokeRect(-3,bodyTop+4,6,6); ctx.strokeRect(p.w-3,bodyTop+4,6,6);
+    if(p.action==='punchRun'){
+      ctx.fillStyle=head; ctx.fillRect(p.w,bodyTop+4,6,6); ctx.fillRect(p.w+6,bodyTop+4,6,6);
+      ctx.strokeStyle=accent; ctx.lineWidth=1; ctx.strokeRect(p.w,bodyTop+4,6,6); ctx.strokeRect(p.w+6,bodyTop+4,6,6);
+    } else {
+      ctx.fillStyle=head; ctx.fillRect(-3,bodyTop+4,6,6); ctx.fillRect(p.w-3,bodyTop+4,6,6);
+      ctx.strokeStyle=accent; ctx.lineWidth=1; ctx.strokeRect(-3,bodyTop+4,6,6); ctx.strokeRect(p.w-3,bodyTop+4,6,6);
+    }
   } else if(id==='leo'){
     ctx.fillStyle=accent; ctx.fillRect(p.w/2-2, headR+1,4,3);
   } else {
@@ -278,14 +284,25 @@ function drawPlayer(x,y,p){
 
   // arms
   ctx.fillStyle = skin;
-  ctx.fillRect(-3,bodyTop+2,6,10);
-  ctx.fillRect(p.w-3,bodyTop+2,6,10);
+  if(id==='abe' && p.action==='punchRun'){
+    ctx.fillRect(p.w,bodyTop+2,6,10);
+    ctx.fillRect(p.w+6,bodyTop+2,6,10);
+  } else {
+    ctx.fillRect(-3,bodyTop+2,6,10);
+    ctx.fillRect(p.w-3,bodyTop+2,6,10);
+  }
 
   // legs with simple step animation
   const legY = p.h-8;
   ctx.fillStyle = '#3b3b3b';
   ctx.fillRect(2,legY+step,6,8);
   ctx.fillRect(p.w-8,legY-step,6,8);
+
+  if(p.action==='bubble'){
+    ctx.strokeStyle='rgba(128,216,255,0.8)';
+    ctx.lineWidth=2;
+    ctx.beginPath(); ellipsePath(p.w/2, p.h/2, p.w, p.h, ctx); ctx.stroke();
+  }
 
   ctx.restore();
 }

--- a/jump-kids/special-moves.js
+++ b/jump-kids/special-moves.js
@@ -19,6 +19,7 @@ export function createSpecialMoves(utils){
       p.lockControls = true;
       p.vx = 300 * p.facing;
       p.cartTime = 0.4;
+      p.cartRot = 0;
     },
     update(p,dt){
       if(p.action==='flip'){
@@ -26,7 +27,8 @@ export function createSpecialMoves(utils){
         if(p.grounded) p.action=null;
       } else if(p.action==='cartwheel'){
         p.cartTime -= dt;
-        if(p.cartTime<=0){ p.action=null; p.lockControls=false; }
+        p.cartRot += dt * Math.PI * 4;
+        if(p.cartTime<=0){ p.action=null; p.lockControls=false; p.cartRot=0; }
       }
     },
     onEnemyCollide(p,e){
@@ -80,10 +82,10 @@ export function createSpecialMoves(utils){
     },
     s2(p){
       if(p.action) return;
-      p.action = 'rush';
+      p.action = 'punchRun';
       p.lockControls = true;
       p.vx = 400 * p.facing; // Fast forward charge
-      p.rushTime = 0.5; // Duration of rush
+      p.punchTime = 0.5; // Duration of run
     },
     update(p,dt,world){
       if(p.action==='smash'){
@@ -112,11 +114,11 @@ export function createSpecialMoves(utils){
           p.lockControls = false;
           p.smashDown = false;
         }
-      } else if(p.action==='rush'){
-        p.rushTime -= dt;
-        if(p.rushTime<=0){ 
-          p.action=null; 
-          p.lockControls=false; 
+      } else if(p.action==='punchRun'){
+        p.punchTime -= dt;
+        if(p.punchTime<=0){
+          p.action=null;
+          p.lockControls=false;
           p.vx *= 0.3; // Slow down after rush
         }
       }
@@ -130,9 +132,7 @@ export function createSpecialMoves(utils){
       }
     },
     onEnemyCollide(p,e){
-      if(p.action==='rush'){
-        // Rush attack knocks enemies back and defeats them
-        e.remove = true;
+      if(p.action==='punchRun'){
         const direction = Math.sign(e.x - p.x) || p.facing;
         e.x += direction * 80; // Strong knockback
         e.vx = direction * 350;
@@ -143,7 +143,29 @@ export function createSpecialMoves(utils){
     }
   },
   leo: {
-    update(p,dt){},
+    update(p,dt,world,keys){
+      if(p.action==='bubble'){
+        p.vx = 0;
+        p.vy = -80;
+        if(!keys.jump || keys.left || keys.right || keys.dash || keys.up || keys.down){
+          p.action=null;
+          p.lockControls=false;
+          p.bubbleHold = 0;
+        }
+        return;
+      }
+      if(keys.jump){
+        p.bubbleHold = (p.bubbleHold||0) + dt;
+        if(p.bubbleHold>=3){
+          p.action='bubble';
+          p.lockControls=true;
+          p.vx=0;
+          p.vy=-80;
+        }
+      } else {
+        p.bubbleHold = 0;
+      }
+    },
     onEnemyCollide(p,e){
       e.remove = true;
       e.vx = Math.sign(e.x - p.x) * 200;


### PR DESCRIPTION
## Summary
- Add spinning cartwheel special for Lucy that knocks back foes
- Rework Abe's S2 into a forward running punch with gloves extended
- Give Leo a bubble float activated by holding jump for three seconds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2cb432f88329bdba3e68374b4a2b