### PR TITLE
feat: add safe start platform

### DIFF
--- a/jump-kids/README.md
+++ b/jump-kids/README.md
@@ -45,6 +45,7 @@ A small, modular browser platformer inspired by classic side‑scrollers. This v
 - Ladders connecting upper, underground, and cavern paths.
 - Rolling hills span the surface while the lower routes reveal a spooky underground cave backdrop.
 - DPI aware canvas sizing; mobile controls; no tile culling to simplify rendering.
+- Start platform in the top-left so players safely spawn away from nearby enemies and return there unless a checkpoint is hit.
 
 ## Characters & Special Moves
 - **Lucy** – S1 high back‑flip jump reaching 1.5× normal height; S2 spinning cartwheel forward that knocks back enemies in her path.

--- a/jump-kids/developers.md
+++ b/jump-kids/developers.md
@@ -16,11 +16,11 @@ Levels are ASCII grids defined by `BASE` and `EXT` arrays in `entities.js`. Each
 - `C` coin
 - `E` Goomba enemy
 - `H` Hellmonk enemy
-- `K` checkpoint flag
-- `G` goal flag (rightmost becomes the end goal)
-- `P` player spawn column
-- `T` trapdoor, `L` ladder, `^` spikes
-`assets/levels/level1.json` uses the same format and can be swapped in from the menu.
+ - `K` checkpoint flag
+ - `G` goal flag (rightmost becomes the end goal)
+ - `P` player spawn column (a start platform is automatically added to the top-left and used as the initial spawn)
+ - `T` trapdoor, `L` ladder, `^` spikes
+ `assets/levels/level1.json` uses the same format and can be swapped in from the menu.
 
 When the player descends beyond roughly 12 tiles, the renderer automatically replaces the hills with a dark cave backdrop.
 

--- a/jump-kids/entities.js
+++ b/jump-kids/entities.js
@@ -53,12 +53,44 @@ export const EXT = [
 "##L###########################################################################################################"
 ];
 
+// Inject a safe start platform at the top-left of the map
+function addStartPlatform(level){
+  const platformRow = 3;      // height for platform
+  const startCol = 0;         // left edge
+  const width = 4;            // platform width in tiles
+
+  // Clear out any existing tiles in the area
+  for (let y = 0; y <= platformRow; y++){
+    if (!level[y]) continue;
+    const row = level[y].split('');
+    for (let x = 0; x < width; x++) row[startCol + x] = '_';
+    level[y] = row.join('');
+  }
+
+  // Add the platform tiles
+  if (level[platformRow]){
+    const row = level[platformRow].split('');
+    for (let x = 0; x < width; x++) row[startCol + x] = '=';
+    level[platformRow] = row.join('');
+  }
+
+  // Place the spawn marker one tile above the platform
+  const spawnRow = platformRow - 1;
+  if (level[spawnRow]){
+    const row = level[spawnRow].split('');
+    row[startCol + Math.floor(width/2)] = 'P';
+    level[spawnRow] = row.join('');
+  }
+}
+
 // Build a unified level array from base and extension segments
 export function buildLevelFromArrays(base, ext){
   const rows = base.slice();
   const extLocal = ext ? ext.slice() : [];
   while (extLocal.length < rows.length) extLocal.push((extLocal[0]||'').padEnd((rows[0]||'').length||96, '_'));
-  return rows.map((row,i)=> row + (extLocal[i]||''));
+  const merged = rows.map((row,i)=> row + (extLocal[i]||''));
+  addStartPlatform(merged);
+  return merged;
 }
 
 export let LEVEL = buildLevelFromArrays(BASE, EXT);
@@ -67,6 +99,7 @@ export let W = LEVEL[0].length;
 
 // Allow game.js to swap in a new level dynamically
 export function setLevel(newLevel){
+  addStartPlatform(newLevel);
   LEVEL = newLevel;
   H = LEVEL.length;
   W = LEVEL[0].length;


### PR DESCRIPTION
## Summary
- automatically insert a start platform in the top-left of every level
- spawn players on this platform until a checkpoint is reached
- document the start platform behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa377ac37c8329859830d00115e3a8