### PR TITLE
Add per-level background music to Jump Kids

### DIFF
--- a/jump-kids/game.js
+++ b/jump-kids/game.js
@@ -1,6 +1,7 @@
 import { buildLevelFromArrays, buildWorld, setLevel, LEVEL, H, W, tileAt, isSolid, groundTopAt, setEnemyConfigs, BASE, EXT } from './entities.js';
 import { createSpecialMoves } from './special-moves.js';
-import { initInput, keys, setWorld as inputSetWorld, setSpecialMoves, setHUD, unlockAudio, playBeep } from './input.js';
+import { initInput, keys, setWorld as inputSetWorld, setSpecialMoves, setHUD, unlockAudio, playBeep, getAudioContext } from './input.js';
+import { initMusic, playMusic, stopMusic } from './music.js';
 import { update as updatePhysics } from './physics.js';
 import { initRenderer, draw, fitCanvas, ellipsePath, setBackdrop } from './rendering.js';
 
@@ -175,7 +176,11 @@ function buildLevelGrid(entries){
 }
 async function startFromMenu(){
   unlockAudio();
+  stopMusic();
+  initMusic(getAudioContext());
   const levelFile = selectedLevelFile || levelSelect.value || 'level1.json';
+  const levelNum = parseInt(levelFile.match(/\d+/)?.[0] || '1', 10);
+  playMusic(levelNum);
   
   // Try to load from JSON first, fallback to built-in data if that fails
   try{

--- a/jump-kids/game_clean.js
+++ b/jump-kids/game_clean.js
@@ -1,6 +1,7 @@
 import { buildLevelFromArrays, buildWorld, setLevel, LEVEL, H, W, tileAt, isSolid, groundTopAt, setEnemyConfigs, BASE, EXT } from './entities.js';
 import { createSpecialMoves } from './special-moves.js';
-import { initInput, keys, setWorld as inputSetWorld, setSpecialMoves, setHUD, unlockAudio, playBeep } from './input.js';
+import { initInput, keys, setWorld as inputSetWorld, setSpecialMoves, setHUD, unlockAudio, playBeep, getAudioContext } from './input.js';
+import { initMusic, playMusic, stopMusic } from './music.js';
 import { update as updatePhysics } from './physics.js';
 import { initRenderer, draw, fitCanvas, ellipsePath, setBackdrop } from './rendering.js';
 
@@ -196,7 +197,11 @@ function buildLevelGrid(entries){
 }
 async function startFromMenu(){
   unlockAudio();
+  stopMusic();
+  initMusic(getAudioContext());
   const levelFile = selectedLevelFile || levelSelect.value || 'level1.json';
+  const levelNum = parseInt(levelFile.match(/\d+/)?.[0] || '1', 10);
+  playMusic(levelNum);
   
   // If running from file protocol, use built-in level data
   if (isFileProtocol) {

--- a/jump-kids/input.js
+++ b/jump-kids/input.js
@@ -23,6 +23,8 @@ export function unlockAudio(){
   try { audioCtx = new (window.AudioContext||window.webkitAudioContext)(); } catch {}
 }
 
+export function getAudioContext(){ return audioCtx; }
+
 export function playBeep(freq=600, dur=0.08, vol=0.08){
   if (!audioReady || !audioCtx) return;
   const o = audioCtx.createOscillator();

--- a/jump-kids/music.js
+++ b/jump-kids/music.js
@@ -1,0 +1,48 @@
+let ctx=null;
+let master=null;
+let timers=[];
+
+const MELODY=[
+  {freq:261.63, dur:0.4},
+  {freq:293.66, dur:0.4},
+  {freq:329.63, dur:0.4},
+  {freq:392.0,  dur:0.4}
+];
+
+export function initMusic(audioCtx){
+  ctx = audioCtx;
+  if (!ctx) return;
+  master = ctx.createGain();
+  master.gain.value = 0.05;
+  master.connect(ctx.destination);
+}
+
+function playNote(note, start, type, pitch){
+  const o = ctx.createOscillator();
+  const g = ctx.createGain();
+  o.type = type;
+  o.frequency.value = note.freq * pitch;
+  g.gain.value = 0.08;
+  o.connect(g); g.connect(master);
+  o.start(start);
+  o.stop(start + note.dur);
+}
+
+export function playMusic(level=1){
+  if (!ctx || !master) return;
+  stopMusic();
+  const waves=['sine','square','triangle','sawtooth'];
+  const wave = waves[(level-1)%waves.length];
+  const pitch = 1 + ((level-1)%4)*0.02;
+  let t = ctx.currentTime;
+  for (const n of MELODY){
+    playNote(n, t, wave, pitch);
+    t += n.dur;
+  }
+  timers.push(setTimeout(()=>playMusic(level), (t-ctx.currentTime)*1000));
+}
+
+export function stopMusic(){
+  timers.forEach(clearTimeout);
+  timers=[];
+}


### PR DESCRIPTION
## Summary
- create looping melody module using Web Audio API
- export audio context to share with music module
- start background music with level-based variations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa5ac26f5c8329997cf415c409b933