### PR TITLE
Fix game start by waiting for menu init before canvas fit

### DIFF
--- a/jump-kids/game.js
+++ b/jump-kids/game.js
@@ -387,8 +387,8 @@ async function initMenu(){
   updateCharSelection(selectedChar || 'lucy', false);
 }
 
-// Initialize immediately
-initMenu();
-
-// Fit canvas to device pixel ratio
-addEventListener('resize', fitCanvas); fitCanvas();
+// Initialize game and then fit canvas to device pixel ratio
+initMenu().then(() => {
+  addEventListener('resize', fitCanvas);
+  fitCanvas();
+});


### PR DESCRIPTION
## Summary
- Delay canvas fitting until after the menu and world initialise

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab659d148c83299b3d9ebba9dddb20