### PR TITLE
Add ramps and adjust collectible behavior in race-abe

### DIFF
--- a/race-abe/race-abe.html
+++ b/race-abe/race-abe.html
@@ -93,12 +93,12 @@
 
 <div id="title">Abe’s Monster Truck – Tiny Racer</div>
 
-<div id="hud">
-  <div>🏁 <span id="distance">0</span> m</div>
-  <div>⭐ <span id="stars">0</span></div>
-  <div>🌀 <span id="speed">0</span> m/s</div>
-  <div>❤️ <span id="health">3</span></div>
-</div>
+  <div id="hud">
+    <div>🏁 <span id="distance">0</span> m</div>
+    <div>⭐ <span id="stars">0</span></div>
+    <div>🌀 <span id="speed">0</span> m/s</div>
+    <div>❤️ <span id="health">10</span></div>
+  </div>
 
 <div id="controls" aria-label="On-screen controls">
   <div style="text-align:center">
@@ -172,7 +172,7 @@
     stars: 0,
     speed: 0,
     damage: 0,
-    maxDamage: 3,
+    maxDamage: 10,
     playing: false,
     crashed: false,
     shake: 0
@@ -246,32 +246,43 @@
   const obstacles = []; // {x, yTop, w, h, hue}
   const stars = [];     // collectibles {x,y, r, taken}
   const hearts = [];    // health pickups {x,y, r, taken}
+  const ramps = [];     // dirt ramps {x, baseY, w, h, used}
   let lastSpawnX = 0;
+  let lastRampX = 0;
   function spawnAhead(){
     const rightEdge = world.scrollX + canvas.width/DPR + 1200;
     while(lastSpawnX < rightEdge){
-      // Place obstacle every 600-900 px
-      lastSpawnX += 600 + rnd()*300;
+      // Vary obstacle spacing - mostly long, sometimes shorter
+      const spacing = (rnd() < 0.3 ? 400 + rnd()*300 : 900 + rnd()*600);
+      lastSpawnX += spacing;
       const gy = groundY(lastSpawnX);
       const h = 40 + rnd()*70;
       const w = 50 + rnd()*50;
       obstacles.push({x:lastSpawnX, yTop:gy - h, w, h, hue: 10+Math.floor(rnd()*40)});
       // Place star above it ~ sometimes
       if(rnd() < 0.8){
-        const sy = gy - h - (60 + rnd()*60);
+        const sy = gy - h - (80 + rnd()*120);
         stars.push({x:lastSpawnX + w*0.5, y: sy, r: 20, taken:false});
       }
       // Occasionally spawn a heart
       if(rnd() < 0.15){
-        const hy = gy - h - (40 + rnd()*40);
+        const hy = gy - h - (100 + rnd()*120);
         hearts.push({x:lastSpawnX + w*0.5, y: hy, r: 16, taken:false});
       }
+    }
+    while(lastRampX < rightEdge){
+      lastRampX += 900 + rnd()*800;
+      const gy = groundY(lastRampX);
+      const w = 140 + rnd()*80;
+      const h = 80 + rnd()*40;
+      ramps.push({x:lastRampX, baseY:gy, w, h, used:false});
     }
     // Cull old
     const minX = world.scrollX - 300;
     while(obstacles.length && obstacles[0].x + obstacles[0].w < minX) obstacles.shift();
     while(stars.length && stars[0].x + 40 < minX) stars.shift();
     while(hearts.length && hearts[0].x + 40 < minX) hearts.shift();
+    while(ramps.length && ramps[0].x + ramps[0].w < minX) ramps.shift();
   }
 
   // ===== Truck =====
@@ -359,10 +370,11 @@
   // ===== Game Control =====
   function resetGame(){
     world.t = 0; world.scrollX=0; world.distance=0; world.speed=0; world.stars=0; world.crashed=false; world.shake=0; world.damage=0;
-    obstacles.length = 0; stars.length=0; hearts.length=0; puffs.length=0;
+    obstacles.length = 0; stars.length=0; hearts.length=0; ramps.length=0; puffs.length=0;
     // Start spawning obstacles ahead of the truck's world position so the
     // player has time to react to upcoming jumps.
     lastSpawnX = truck.baseX;
+    lastRampX = truck.baseX;
     truck.y = groundY(truck.baseX) - truck.wheelR; truck.vy=0; truck.onGround=true; truck.angle=0; truck.spin=0;
     spawnAhead();
     crashOverlay.style.display='none';
@@ -427,6 +439,18 @@
 
       // Spawn ahead / cull
       spawnAhead();
+      
+      // Ramps
+      for(const r of ramps){
+        if(r.used) continue;
+        const rx = r.x - world.scrollX;
+        if(truck.onGround && rx < truck.baseX && rx + r.w > truck.baseX){
+          r.used = true;
+          truck.vy = -world.jumpVel*1.5;
+          truck.onGround = false;
+          playBeep();
+        }
+      }
 
       // Collect stars
       for(const s of stars){
@@ -545,12 +569,18 @@
     // Background hills
     drawHills();
 
-    // Track
-    drawGround();
+      // Track
+      drawGround();
 
-    // Stars
-    for(const s of stars){
-      if(s.taken) continue;
+      // Ramps
+      for(const r of ramps){
+        const x = r.x - world.scrollX;
+        drawRamp(x, r.baseY, r.w, r.h);
+      }
+
+      // Stars
+      for(const s of stars){
+        if(s.taken) continue;
       const x = s.x - world.scrollX;
       drawStar(x, s.y, s.r);
     }
@@ -668,6 +698,22 @@
     }
     ctx.stroke();
     ctx.setLineDash([]);
+  }
+
+  function drawRamp(x, baseY, w, h){
+    ctx.save();
+    ctx.translate(x, baseY);
+    ctx.fillStyle = '#b45309';
+    ctx.strokeStyle = '#92400e';
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(0,0);
+    ctx.lineTo(w,-h);
+    ctx.lineTo(w,0);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+    ctx.restore();
   }
 
   function drawObstacle(x, yTop, w, h, hue){


### PR DESCRIPTION
## Summary
- Spread obstacles out with variable gaps and elevate hearts and stars for easier pickups
- Start players with 10 hearts and spawn dirt ramps that grant big jumps
- Draw new ramps and handle ramp-triggered boosts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3271a2cf88329ba1fd5ddce295c8a