### PR TITLE
Add peg game to landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # ltrgordon.github.io
 
-This repository contains the source for a static personal site. The `beamer` directory hosts a browser game that simulates a pong-style battle with light refraction through a lens.
+This repository contains the source for a static personal site featuring several classic-inspired mini-games:
+
+- Jump Kids — dash, jump, and clear the level.
+- Beamer — a pong-style battle with light refraction through a lens.
+- Jump Abe — race Abe's monster truck.
+- Peg Game — the classic triangular peg-jumping puzzle.
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -104,6 +104,16 @@
           <span class="cta">Play <span class="arr">→</span></span>
         </div>
       </a>
+      <a class="card" href="./peg-triangle-game.html" aria-label="Play Peg Game">
+        <div class="art">
+          <canvas id="art-pg" width="480" height="360" aria-hidden="true"></canvas>
+        </div>
+        <div class="details">
+          <div class="name">Peg Game</div>
+          <div class="desc">Jump the pegs to solve the puzzle.</div>
+          <span class="cta">Play <span class="arr">→</span></span>
+        </div>
+      </a>
     </main>
     <footer>Use keyboard or touch — have fun!</footer>
   </div>
@@ -148,7 +158,19 @@
       x.beginPath(); x.arc(W/2-30,H-60,20,0,Math.PI*2); x.fill();
       x.beginPath(); x.arc(W/2+30,H-60,20,0,Math.PI*2); x.fill();
     }
-    drawJK(); drawBM(); drawJA();
+    function drawPG(){
+      const c = document.getElementById('art-pg'); if(!c) return; const x=c.getContext('2d'); const W=c.width, H=c.height;
+      x.clearRect(0,0,W,H);
+      const g = x.createLinearGradient(0,0,0,H); g.addColorStop(0,'#f5f5f4'); g.addColorStop(1,'#e7e5e4'); x.fillStyle=g; x.fillRect(0,0,W,H);
+      // board
+      x.fillStyle='#a16207';
+      x.beginPath(); x.moveTo(W/2,80); x.lineTo(80,H-80); x.lineTo(W-80,H-80); x.closePath(); x.fill();
+      // pegs
+      x.fillStyle='#f59e0b';
+      const pts=[[W/2,110],[W/2-40,160],[W/2+40,160],[W/2-80,210],[W/2,210],[W/2+80,210]];
+      pts.forEach(([px,py])=>{x.beginPath(); x.arc(px,py,10,0,Math.PI*2); x.fill();});
+    }
+    drawJK(); drawBM(); drawJA(); drawPG();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- feature: add Peg Game to landing page with custom art
- docs: list all four games in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b375b2068883299394ebf07718c19d