### PR TITLE
Fix Peg Solitaire board initialization error

### DIFF
--- a/peg-solitaire.html
+++ b/peg-solitaire.html
@@ -252,6 +252,9 @@
 
 <script>
 (() => {
+  let pegColor = '#77a7ff';
+  let pegGradStop = null;
+
   const boardSvg = document.getElementById('board');
   const boardTypeSel = document.getElementById('boardType');
 
@@ -284,8 +287,6 @@
   let history = [];
   let choosingStart = false;
   let hintOn = false;
-  let pegColor = '#77a7ff';
-  let pegGradStop = null;
   let currentBoard = 'triangle';
   const bestScores = {};
   const demoSequences = {


### PR DESCRIPTION
## Summary
- Initialize `pegColor` and `pegGradStop` before they are used, preventing a runtime error that stopped the board from rendering.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f542d23c8329b7d79b169cbee7a0