### PR TITLE
Reduce jump height, add 5s rocket-jump cooldown, and add long slopes

### DIFF
--- a/race-abe/race-abe.html
+++ b/race-abe/race-abe.html
@@ -181,7 +181,7 @@
   <div class="card">
     <h1>Welcome!</h1>
     <p>Tap <b>▶️</b> to start the monster truck.</p>
-    <p>Use <b>⛔</b> to brake, <b>⤴️</b> or the <b>space bar</b> to jump, and <b>📢</b> to honk. Colliding with crates releases confetti.</p>
+    <p>Use <b>⛔</b> to brake, <b>⤴️</b> or the <b>space bar</b> for a rocket jump (5s cooldown), and <b>📢</b> to honk. Colliding with crates releases confetti.</p>
     <p>Grab health boxes to repair the truck after crashes.</p>
     <label><input type="checkbox" id="zoomToggle" /> Dynamic zoom (zoom in/out while jumping)</label>
     <div class="levelPicker" id="levelPicker">
@@ -273,7 +273,9 @@
     reverseAccel: 900,    // px/s^2
     reverseBrake: 1600,   // px/s^2
     reverseMaxSpeed: 360, // px/s
-    jumpVel: 900,         // px/s
+    jumpVel: 585,         // px/s (about 35% lower jump)
+    manualJumpCooldown: 0,
+    manualJumpCooldownDuration: 5,
     distance: 0,
     stars: 0,
     tntHit: 0,
@@ -307,8 +309,9 @@
       hillNear: '#e8c97a', hillFar: '#d4a843',
       terrainTop: '#e8c97a', terrainMid: '#d4a843', terrainBottom: '#a07030', edge: '#c9a04a', lane: '#fff7ed',
       bumpA: 60, bumpB: 25, bumpC: 35, bumpD: 25, rockySharpness: 0, jaggedAmp: 0, streamChance: 0.08, greenery: 0.16, waterfallChance: 0.02,
+      longSlopeMeters: 700, longSlopeHeight: 180,
       obstacleBias: { boulder: 0.02, cactus: 0.18 },
-      rampSpacingMin: 2800, rampSpacingMax: 4800, rampWidth: [160, 240], rampHeight: [38, 60], turboChance: 0.20,
+      rampSpacingMin: 2800, rampSpacingMax: 4800, rampWidth: [160, 240], rampHeight: [24, 39], turboChance: 0.20,
       rainbowChance: 0.035, lowGravityDuration: 15, bubbleDuration: 8, flameDuration: 4, invincibleDuration: 5
     },
     rockies: {
@@ -317,8 +320,9 @@
       hillNear: '#6b7c50', hillFar: '#8a9e6a',
       terrainTop: '#5a6e40', terrainMid: '#7a6040', terrainBottom: '#4a3a28', edge: '#4a5a30', lane: '#dbeafe',
       bumpA: 30, bumpB: 18, bumpC: 22, bumpD: 65, rockySharpness: 42, jaggedAmp: 24, streamChance: 0.24, greenery: 0.44, waterfallChance: 0.18,
+      longSlopeMeters: 620, longSlopeHeight: 220,
       obstacleBias: { boulder: 0.26, cactus: 0.02 },
-      rampSpacingMin: 1800, rampSpacingMax: 3000, rampWidth: [180, 320], rampHeight: [58, 110], turboChance: 0.34,
+      rampSpacingMin: 1800, rampSpacingMax: 3000, rampWidth: [180, 320], rampHeight: [38, 72], turboChance: 0.34,
       rainbowChance: 0.018, lowGravityDuration: 15, bubbleDuration: 8, flameDuration: 4, invincibleDuration: 5
     },
     himalayas: {
@@ -327,8 +331,9 @@
       hillNear: '#94a3b8', hillFar: '#cbd5e1',
       terrainTop: '#f8fafc', terrainMid: '#cbd5e1', terrainBottom: '#475569', edge: '#e2e8f0', lane: '#ffffff',
       bumpA: 74, bumpB: 44, bumpC: 26, bumpD: 110, rockySharpness: 78, jaggedAmp: 42, streamChance: 0.14, greenery: 0.12, waterfallChance: 0.08,
+      longSlopeMeters: 500, longSlopeHeight: 340, longSlopeMode: 'himalayaSteep',
       obstacleBias: { boulder: 0.34, cactus: 0 },
-      rampSpacingMin: 1400, rampSpacingMax: 2450, rampWidth: [170, 300], rampHeight: [82, 150], turboChance: 0.4,
+      rampSpacingMin: 1400, rampSpacingMax: 2450, rampWidth: [170, 300], rampHeight: [53, 98], turboChance: 0.4,
       rainbowChance: 0.022, lowGravityDuration: 16, bubbleDuration: 9, flameDuration: 4, invincibleDuration: 5
     },
     moon: {
@@ -337,8 +342,9 @@
       hillNear: '#6b7280', hillFar: '#374151',
       terrainTop: '#d1d5db', terrainMid: '#9ca3af', terrainBottom: '#4b5563', edge: '#f3f4f6', lane: '#e5e7eb',
       bumpA: 42, bumpB: 24, bumpC: 16, bumpD: 58, rockySharpness: 24, jaggedAmp: 14, streamChance: 0, greenery: 0, waterfallChance: 0,
+      longSlopeMeters: 680, longSlopeHeight: 170,
       obstacleBias: { boulder: 0.18, cactus: 0 },
-      rampSpacingMin: 1650, rampSpacingMax: 2500, rampWidth: [180, 320], rampHeight: [88, 160], turboChance: 0.44,
+      rampSpacingMin: 1650, rampSpacingMax: 2500, rampWidth: [180, 320], rampHeight: [57, 104], turboChance: 0.44,
       rainbowChance: 0.028, lowGravityDuration: 20, bubbleDuration: 12, flameDuration: 5, invincibleDuration: 6,
       gravityScale: 0.38, jumpBoost: 1.22, craterChance: 0.17, craterDepth: [120, 220], craterWidth: [220, 460],
       halfpipeChance: 0.045, halfpipeRadius: [320, 520], halfpipeSpacing: 5500
@@ -517,6 +523,22 @@
         const bowlDip = hpRadius * (1.0 - Math.sqrt(Math.max(0, 1 - norm*norm)));
         y += bowlDip;
       }
+    }
+    if(level.longSlopeMeters && level.longSlopeHeight){
+      const meters = x / 40;
+      const slopeLen = level.longSlopeMeters;
+      const cycle = slopeLen * 2;
+      const phase = ((meters % cycle) + cycle) % cycle;
+      let slopeFactor;
+      if(level.longSlopeMode === 'himalayaSteep'){
+        slopeFactor = phase < slopeLen
+          ? 1 - (phase / slopeLen) * 2
+          : -1 + ((phase - slopeLen) / slopeLen) * 2;
+      }else{
+        // Other levels: smooth sustained climbs and drops.
+        slopeFactor = Math.sin((meters / cycle) * Math.PI * 2);
+      }
+      y += slopeFactor * level.longSlopeHeight;
     }
     return y;
   }
@@ -880,7 +902,7 @@
   // ===== Game Control =====
   function resetGame(){
     document.getElementById('title').textContent = `Abe’s Monster Truck – ${currentLevel().name}`;
-    world.t = 0; world.scrollX=0; world.distance=0; world.speed=0; world.stars=0; world.tntHit=0; world.bricksCollected=0; world.crashed=false; world.shake=0; world.damage=0; world.flameBoostTimer=0; world.lowGravityTimer=0; world.invincibleTimer=0; world.bubbleTimer=0; world.cameraZoom=1; world.cameraYOffset=0; world.greenBricks=0; world.redBricks=0; world.blueBricks=0; world.maxSpeed=world.baseMaxSpeed; world.timeLeft=60; world.timeElapsed=0;
+    world.t = 0; world.scrollX=0; world.distance=0; world.speed=0; world.stars=0; world.tntHit=0; world.bricksCollected=0; world.crashed=false; world.shake=0; world.damage=0; world.flameBoostTimer=0; world.lowGravityTimer=0; world.invincibleTimer=0; world.bubbleTimer=0; world.cameraZoom=1; world.cameraYOffset=0; world.greenBricks=0; world.redBricks=0; world.blueBricks=0; world.maxSpeed=world.baseMaxSpeed; world.timeLeft=60; world.timeElapsed=0; world.manualJumpCooldown=0;
     obstacles.length = 0; stars.length=0; medkits.length=0; hourglasses.length=0; flames.length=0; lowGravityOrbs.length=0; rainbowPowerups.length=0; bricks.length=0; ramps.length=0; scenery.length=0; puffs.length=0; floatTexts.length=0;
     // Start spawning obstacles ahead of the truck's world position so the
     // player has time to react to upcoming jumps.
@@ -918,6 +940,7 @@
         finishGame(false);
         return;
       }
+      world.manualJumpCooldown = Math.max(0, world.manualJumpCooldown - dt);
       // Input to speed
       if(input.go){
         if(world.speed < 0) world.speed += world.reverseBrake * dt;
@@ -935,8 +958,22 @@
 
       // Jump
       if(input.jump){
-        if(truck.onGround){
+        if(truck.onGround && world.manualJumpCooldown <= 0){
           truck.vy = -world.jumpVel * (0.95 + 0.1*Math.min(1, world.speed/world.maxSpeed)) * (currentLevel().jumpBoost || 1) * (hasLowGravityBoost() ? 1.25 : 1);
+          world.manualJumpCooldown = world.manualJumpCooldownDuration;
+          for(let i=0;i<34;i++){
+            const spread = (Math.random()*2-1);
+            puffs.push({
+              x:truck.baseX + spread * 22,
+              y:truck.y + 6 + Math.random()*22,
+              vx:spread * (120 + Math.random()*220),
+              vy:120 + Math.random()*260,
+              life:0,
+              ttl:0.35 + Math.random()*0.25,
+              color:Math.random() < 0.5 ? '#fb923c' : '#facc15',
+              size:4 + Math.random()*5
+            });
+          }
           playBeep();
         }
         input.jump=false;
@@ -962,13 +999,13 @@
         // produce large upward velocities.
         const slopeVy = surfaceDY * world.speed;
         const isOnRamp = activeRamp !== null;
-        const maxGroundLaunch = isOnRamp ? -Infinity : -120; // clamp upward bounce on flat ground
+        const maxGroundLaunch = isOnRamp ? -Infinity : -70; // clamp upward bounce on flat ground
         truck.vy = Math.max(maxGroundLaunch, Math.min(slopeVy, 400));
         truck.onGround = true;
         if(activeRamp?.turbo && !activeRamp.used){
           activeRamp.used = true;
           world.speed = Math.min(world.maxSpeed + 520, Math.max(world.speed, world.maxSpeed * 0.92) + 420);
-          truck.vy = Math.min(truck.vy, -960);
+          truck.vy = Math.min(truck.vy, -620);
           world.shake = Math.max(world.shake, 8);
           playBeep();
           for(let i=0;i<36;i++){


### PR DESCRIPTION
### Motivation
- Make airborne time and bounce less extreme by lowering jump heights and tamping non-ramp bounce. 
- Add a manual "rocket" jump that has a clear gameplay cost (cooldown) to prevent spamming boosts. 
- Make level pacing feel more sustained by adding long uphill/downhill sections, with Himalayas implementing repeating 500m uphill/500m downhill segments.

### Description
- Lowered global base jump velocity by changing `world.jumpVel` from `900` to `585` and reduced ramp height ranges per level to cut jump height (~30–40% lower). 
- Added a manual jump cooldown using `world.manualJumpCooldown` and `world.manualJumpCooldownDuration` (set to `5` seconds) and prevent manual jumps while the cooldown is active. 
- When a manual jump triggers the cooldown, spawn a visible rocket-blast particle burst underneath the truck and play the jump sound. The cooldown is reset on `resetGame` and ticks down each frame. 
- Reduced non-ramp ground bounce by changing the flat-ground upward clamp from `-120` to `-70` and limited turbo ramp upward kick from `-960` to `-620`. 
- Introduced `longSlopeMeters` and `longSlopeHeight` level parameters and added logic in `groundY(x)` to create sustained climbs/drops; `himalayas` gets `longSlopeMeters: 500` with `longSlopeMode: 'himalayaSteep'` (500m steep up then 500m steep down repeating), and other levels receive longer smoother slope parameters. 
- Updated UI start text to mention the rocket jump and the 5s cooldown to inform players (start overlay). 

### Testing
- Ran `npm test` which executes the project's automated test suite; output: "All utility tests passed.", "All snake tests passed.", and "All tests passed." (suite succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dadcef78a4832986e50f4dd7053caa)