### PR TITLE
Fix race-abe ground clipping and modernize pickup visuals

### DIFF
--- a/race-abe/race-abe.html
+++ b/race-abe/race-abe.html
@@ -538,7 +538,10 @@
       }
       y += slopeFactor * level.longSlopeHeight;
     }
-    return y;
+    const viewH = canvas.height / DPR;
+    const maxGroundY = viewH - Math.max(130, truck.wheelR + truck.bodyH * 0.95);
+    const minGroundY = Math.max(170, viewH * 0.36);
+    return Math.max(minGroundY, Math.min(maxGroundY, y));
   }
 
   function trackBaseY(x, width){
@@ -2121,12 +2124,26 @@
     const [fill, stroke] = palette[color] || palette.green;
     ctx.save();
     ctx.translate(x, y);
-    ctx.fillStyle = fill;
-    roundRect(ctx, -size/2, -size/2, size, size, 8, true, false);
-    ctx.strokeStyle = stroke;
-    ctx.lineWidth = 3;
+    const t = world.t;
+    const hover = Math.sin(t * 5 + x * 0.01) * 3;
+    ctx.translate(0, hover);
+    const glow = ctx.createRadialGradient(0, 0, size*0.25, 0, 0, size*1.1);
+    glow.addColorStop(0, `${fill}cc`);
+    glow.addColorStop(1, `${fill}00`);
+    ctx.fillStyle = glow;
+    ctx.beginPath(); ctx.arc(0, 0, size*0.75, 0, Math.PI*2); ctx.fill();
+    const body = ctx.createLinearGradient(-size*0.4, -size*0.6, size*0.4, size*0.6);
+    body.addColorStop(0, '#ffffff');
+    body.addColorStop(0.18, fill);
+    body.addColorStop(1, stroke);
+    ctx.fillStyle = body;
+    roundRect(ctx, -size/2, -size/2, size, size, 14, true, false);
+    ctx.strokeStyle = '#f8fafc';
+    ctx.lineWidth = 4;
     ctx.stroke();
-    ctx.strokeRect(-size*0.34, -size*0.18, size*0.68, size*0.36);
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = 2.5;
+    roundRect(ctx, -size*0.28, -size*0.23, size*0.56, size*0.46, 8, false, true);
     ctx.restore();
   }
 
@@ -2151,9 +2168,21 @@
   function drawStar(x, y, r){
     ctx.save();
     ctx.translate(x,y);
-    ctx.fillStyle = '#fde047';
-    ctx.strokeStyle = '#f59e0b';
-    ctx.lineWidth = 3;
+    const pulse = 1 + 0.07*Math.sin(world.t * 10 + x * 0.025);
+    ctx.scale(pulse, pulse);
+    const outerGlow = ctx.createRadialGradient(0,0,r*0.15,0,0,r*1.6);
+    outerGlow.addColorStop(0,'#fff7b3dd');
+    outerGlow.addColorStop(0.55,'#facc15aa');
+    outerGlow.addColorStop(1,'#facc1500');
+    ctx.fillStyle = outerGlow;
+    ctx.beginPath(); ctx.arc(0,0,r*1.5,0,Math.PI*2); ctx.fill();
+    const starGrad = ctx.createLinearGradient(0,-r,0,r);
+    starGrad.addColorStop(0,'#fef9c3');
+    starGrad.addColorStop(0.45,'#fde047');
+    starGrad.addColorStop(1,'#f59e0b');
+    ctx.fillStyle = starGrad;
+    ctx.strokeStyle = '#b45309';
+    ctx.lineWidth = 2.5;
     ctx.beginPath();
     const spikes=5;
     let rot = Math.PI/2*3, step = Math.PI/spikes;
@@ -2171,6 +2200,11 @@
     ctx.translate(x, y);
     const flicker = 0.8 + Math.sin(world.t*24 + x*0.02)*0.2;
     const inner = r * flicker;
+    const aura = ctx.createRadialGradient(0,0,r*0.2,0,0,r*1.7);
+    aura.addColorStop(0,'#fb923caa');
+    aura.addColorStop(1,'#fb923c00');
+    ctx.fillStyle = aura;
+    ctx.beginPath(); ctx.arc(0,0,r*1.6,0,Math.PI*2); ctx.fill();
     ctx.fillStyle = '#fb923c';
     ctx.beginPath();
     ctx.moveTo(0,-inner);
@@ -2183,19 +2217,30 @@
     ctx.quadraticCurveTo(inner*0.35,0,0,inner*0.55);
     ctx.quadraticCurveTo(-inner*0.35,0,0,-inner*0.6);
     ctx.fill();
-    ctx.strokeStyle = '#7c2d12';
-    ctx.lineWidth = 3;
-    ctx.strokeRect(-r*0.45, r*0.62, r*0.9, r*0.28);
+    ctx.fillStyle = '#1f2937';
+    roundRect(ctx, -r*0.46, r*0.58, r*0.92, r*0.34, r*0.12, true, false);
+    ctx.fillStyle = '#f8fafc';
+    ctx.fillRect(-r*0.22, r*0.69, r*0.44, r*0.06);
     ctx.restore();
   }
 
   function drawHealthBox(x, y, size){
     ctx.save();
     ctx.translate(x, y);
-    ctx.fillStyle = '#ffffff';
-    ctx.strokeStyle = '#e5e7eb';
+    const bob = Math.sin(world.t * 6 + x * 0.01) * 3;
+    ctx.translate(0, bob);
+    const glow = ctx.createRadialGradient(0, 0, size*0.2, 0, 0, size*1.25);
+    glow.addColorStop(0, '#fda4af88');
+    glow.addColorStop(1, '#fda4af00');
+    ctx.fillStyle = glow;
+    ctx.beginPath(); ctx.arc(0,0,size*0.84,0,Math.PI*2); ctx.fill();
+    const body = ctx.createLinearGradient(-size*0.4,-size*0.5,size*0.4,size*0.5);
+    body.addColorStop(0,'#ffffff');
+    body.addColorStop(1,'#fee2e2');
+    ctx.fillStyle = body;
+    ctx.strokeStyle = '#fecdd3';
     ctx.lineWidth = 3;
-    roundRect(ctx, -size/2, -size/2, size, size, 6, true, true);
+    roundRect(ctx, -size/2, -size/2, size, size, 12, true, true);
     const crossW = size * 0.62;
     const arm = size * 0.2;
     ctx.fillStyle = '#dc2626';
@@ -2208,6 +2253,8 @@
     ctx.save();
     ctx.translate(x, y);
     const large = value >= 10;
+    const pulse = 0.96 + 0.08*Math.sin(world.t * 7 + x * 0.017);
+    ctx.scale(pulse, pulse);
     ctx.strokeStyle = large ? '#f59e0b' : '#fbbf24';
     ctx.fillStyle = large ? '#fef3c7' : '#fde68a';
     ctx.lineWidth = large ? 4 : 3;
@@ -2232,7 +2279,7 @@
     ctx.fill();
     ctx.font = `bold ${large ? 22 : 16}px Arial`;
     ctx.textAlign = 'center';
-    ctx.fillStyle = '#166534';
+    ctx.fillStyle = '#065f46';
     ctx.fillText(`+${value}`, 0, r + 24);
     ctx.restore();
   }


### PR DESCRIPTION
### Motivation
- Prevent the truck from starting or traveling below the bottom edge of the viewport in steep segments (Himalayas, Moon, etc.) so the vehicle is always fully visible. 
- Make pickups and collectibles look more polished and readable at speed, matching a modern platformer style. 

### Description
- Clamp the terrain height returned by `groundY()` to a visible vertical band tied to `canvas.height / DPR` and truck dimensions so the ground cannot move out of view. 
- Revamped collectible rendering inside `race-abe/race-abe.html` by adding layered gradients, radial glows/auras, and subtle animated hover/pulse transforms. 
- Reworked specific draw routines for pickups: `drawCollectibleBrick`, `drawStar`, `drawFlamePickup`, `drawHealthBox`, and `drawHourglass` to use polished visuals (gloss, glow, rounded shapes, bobbing/pulse). 
- Kept all changes scoped to `race-abe/race-abe.html` and preserved existing spawn/collision logic and game behavior. 

### Testing
- Ran a repository diff (`git diff`) to verify the intended changes to `race-abe/race-abe.html` and inspected the updated sections. 
- Performed a commit of the modified file which completed successfully. 
- Note: there are no automated gameplay/unit tests for this HTML game; visual/behavioral validation is recommended by running the game in a browser to confirm the truck remains visible and pickups render/animate as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6755eee708329bb81be0bf0c67473)