### PR TITLE
Add 3D-Snake game and launcher card

### DIFF
--- a/3d-snake/index.html
+++ b/3d-snake/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D-Snake</title>
+  <style>
+    :root{--bg:#020617;--panel:#0f172a;--ink:#e2e8f0;--accent:#22d3ee;}
+    *{box-sizing:border-box}
+    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial,sans-serif;background:radial-gradient(circle at top,#082f49 0%,#020617 58%);color:var(--ink);min-height:100vh;display:grid;place-items:center;padding:20px}
+    .game-shell{width:min(1100px,95vw);display:grid;grid-template-columns:1fr 300px;gap:18px}
+    canvas{width:100%;aspect-ratio:16/10;background:linear-gradient(180deg,#0ea5e9,#0b1024 40%,#020617);border-radius:18px;border:1px solid #33415566;box-shadow:0 20px 50px #000a}
+    .panel{background:linear-gradient(180deg,#0f172aee,#020617ee);border:1px solid #33415566;border-radius:18px;padding:16px}
+    .score{font-size:36px;font-weight:900;color:#67e8f9;margin:6px 0 20px}
+    .keys{line-height:1.6;color:#cbd5e1;font-size:14px}
+    .overlay{position:absolute;inset:0;display:none;place-items:center;text-align:center;background:#000a;border-radius:18px}
+    .overlay.show{display:grid}
+    .overlay h2{font-size:48px;margin:0 0 8px;color:#f43f5e}
+    .overlay button{border:none;background:linear-gradient(90deg,#22d3ee,#0ea5e9);color:#001;padding:12px 18px;border-radius:999px;font-weight:800;cursor:pointer}
+    .stage{position:relative}
+    @media(max-width:900px){.game-shell{grid-template-columns:1fr}}
+  </style>
+</head>
+<body>
+  <div class="game-shell">
+    <div class="stage">
+      <canvas id="game" width="1200" height="760"></canvas>
+      <div class="overlay" id="overlay">
+        <div>
+          <h2>GAME OVER</h2>
+          <p id="finalScore">Score: 0</p>
+          <button id="restartBtn">Play Again</button>
+        </div>
+      </div>
+    </div>
+    <aside class="panel">
+      <h1 style="margin:0">3D-Snake</h1>
+      <p>Swim through a water cube, collect apples, and don't bite yourself.</p>
+      <div>Score</div><div class="score" id="score">0</div>
+      <div class="keys">
+        <strong>Controls</strong><br>
+        W/A/S/D: Up/Left/Down/Right<br>
+        ↑ : Into screen (deeper)<br>
+        ↓ : Out of screen (closer)
+      </div>
+    </aside>
+  </div>
+<script>
+(() => {
+const SIZE = 8;
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const scoreEl = document.getElementById('score');
+const overlay = document.getElementById('overlay');
+const finalScoreEl = document.getElementById('finalScore');
+const restartBtn = document.getElementById('restartBtn');
+
+let snake, dir, nextDir, apple, score, over, acc=0;
+const speedMs = 160;
+
+const dirs = {
+  left:{x:-1,y:0,z:0}, right:{x:1,y:0,z:0}, up:{x:0,y:-1,z:0}, down:{x:0,y:1,z:0},
+  in:{x:0,y:0,z:1}, out:{x:0,y:0,z:-1}
+};
+function eq(a,b){return a.x===b.x&&a.y===b.y&&a.z===b.z;}
+function wrap(v){return (v+SIZE)%SIZE;}
+
+function reset(){
+  snake=[{x:3,y:4,z:4},{x:2,y:4,z:4},{x:1,y:4,z:4}];
+  dir=dirs.right; nextDir=dir; score=0; over=false; acc=0;
+  placeApple(); scoreEl.textContent = score; overlay.classList.remove('show');
+}
+function placeApple(){
+  do { apple={x:(Math.random()*SIZE)|0,y:(Math.random()*SIZE)|0,z:(Math.random()*SIZE)|0}; }
+  while(snake.some(s=>eq(s,apple)));
+}
+
+window.addEventListener('keydown', e=>{
+  const m={a:dirs.left,d:dirs.right,w:dirs.up,s:dirs.down,ArrowUp:dirs.in,ArrowDown:dirs.out}[e.key];
+  if(!m) return;
+  if(m.x===-dir.x&&m.y===-dir.y&&m.z===-dir.z) return;
+  nextDir=m; e.preventDefault();
+});
+restartBtn.onclick=reset;
+
+function project(p){
+  const cx=canvas.width*0.52, cy=canvas.height*0.52;
+  const sx=56, sy=30, sz=22;
+  return {x:cx+(p.x-p.y)*sx,y:cy+(p.x+p.y)*sy - p.z*sz, zOrder:p.x+p.y+p.z};
+}
+
+function drawCube(){
+  const corners=[];
+  for(const z of [0,SIZE]) for(const y of [0,SIZE]) for(const x of [0,SIZE]) corners.push(project({x,y,z}));
+  const edge = [[0,1],[0,2],[0,4],[1,3],[1,5],[2,3],[2,6],[3,7],[4,5],[4,6],[5,7],[6,7]];
+  ctx.strokeStyle='rgba(125,211,252,.35)'; ctx.lineWidth=2;
+  edge.forEach(([a,b])=>{ctx.beginPath();ctx.moveTo(corners[a].x,corners[a].y);ctx.lineTo(corners[b].x,corners[b].y);ctx.stroke();});
+}
+
+function drawCell(cell, type, i=0){
+  const p=project({x:cell.x+0.5,y:cell.y+0.5,z:cell.z+0.5});
+  const s=24;
+  if(type==='apple'){
+    ctx.fillStyle='#ef4444'; ctx.beginPath(); ctx.arc(p.x,p.y,s*0.55,0,Math.PI*2); ctx.fill();
+    ctx.strokeStyle='#166534'; ctx.lineWidth=3; ctx.beginPath(); ctx.moveTo(p.x+2,p.y-s*0.5); ctx.lineTo(p.x+8,p.y-s*0.85); ctx.stroke();
+    return;
+  }
+  ctx.fillStyle = i%2===0 ? '#22c55e' : '#facc15';
+  ctx.strokeStyle='#111827'; ctx.lineWidth=2;
+  ctx.beginPath();
+  ctx.moveTo(p.x, p.y-s);
+  ctx.lineTo(p.x+s, p.y);
+  ctx.lineTo(p.x, p.y+s);
+  ctx.lineTo(p.x-s, p.y);
+  ctx.closePath(); ctx.fill(); ctx.stroke();
+  ctx.fillStyle='#000';
+  ctx.beginPath(); ctx.moveTo(p.x,p.y-s*0.45); ctx.lineTo(p.x+s*0.25,p.y); ctx.lineTo(p.x,p.y+s*0.45); ctx.lineTo(p.x-s*0.25,p.y); ctx.closePath(); ctx.fill();
+}
+
+function drawHead(){
+  const h=snake[0]; const p=project({x:h.x+0.5,y:h.y+0.5,z:h.z+0.5});
+  ctx.fillStyle='#f8fafc';
+  ctx.beginPath(); ctx.arc(p.x-6,p.y-8,2.3,0,Math.PI*2); ctx.fill();
+  ctx.beginPath(); ctx.arc(p.x+6,p.y-8,2.3,0,Math.PI*2); ctx.fill();
+  ctx.fillStyle='#b91c1c';
+  ctx.beginPath(); ctx.moveTo(p.x,p.y+4); ctx.lineTo(p.x-4,p.y+13); ctx.lineTo(p.x-1,p.y+10); ctx.moveTo(p.x,p.y+4); ctx.lineTo(p.x+4,p.y+13); ctx.lineTo(p.x+1,p.y+10); ctx.strokeStyle='#dc2626'; ctx.lineWidth=2; ctx.stroke();
+  ctx.fillStyle='#fff';
+  ctx.fillRect(p.x-10,p.y-1,2,4); ctx.fillRect(p.x+8,p.y-1,2,4);
+}
+
+function tick(){
+  dir=nextDir;
+  const n={x:wrap(snake[0].x+dir.x),y:wrap(snake[0].y+dir.y),z:wrap(snake[0].z+dir.z)};
+  if(snake.some(s=>eq(s,n))){over=true; overlay.classList.add('show'); finalScoreEl.textContent=`Score: ${score}`; return;}
+  snake.unshift(n);
+  if(eq(n,apple)){score++; scoreEl.textContent=score; placeApple();}
+  else snake.pop();
+}
+
+function draw(){
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  drawCube();
+  const render=[];
+  snake.forEach((s,i)=>render.push({...s,kind:'snake',idx:i,depth:s.x+s.y+s.z}));
+  render.push({...apple,kind:'apple',depth:apple.x+apple.y+apple.z});
+  render.sort((a,b)=>a.depth-b.depth).forEach(o=>o.kind==='apple'?drawCell(o,'apple'):drawCell(o,'snake',o.idx));
+  drawHead();
+}
+
+let last=performance.now();
+function frame(t){
+  const dt=t-last; last=t; if(!over){acc+=dt; while(acc>=speedMs){tick(); acc-=speedMs;}}
+  draw(); requestAnimationFrame(frame);
+}
+reset(); requestAnimationFrame(frame);
+})();
+</script>
+</body>
+</html>

--- a/games/index.html
+++ b/games/index.html
@@ -144,6 +144,16 @@
           <span class="cta" style="background:linear-gradient(90deg,#6366f1,#4f46e5)">Play <span class="arr">→</span></span>
         </div>
       </a>
+      <a class="card" href="../3d-snake/index.html" aria-label="Play 3D-Snake">
+        <div class="art">
+          <canvas id="art-3dsn" width="480" height="360" aria-hidden="true"></canvas>
+        </div>
+        <div class="details">
+          <div class="name">3D-Snake</div>
+          <div class="desc">Swim the cube, wrap walls, and avoid yourself.</div>
+          <span class="cta" style="background:linear-gradient(90deg,#06b6d4,#0ea5e9)">Play <span class="arr">→</span></span>
+        </div>
+      </a>
     </main>
     <footer>Use keyboard or touch — have fun!</footer>
   </div>
@@ -240,7 +250,18 @@
       x.strokeStyle='#f43f5e'; x.lineWidth=6;
       x.beginPath(); x.moveTo(W/2+35,H-200); x.lineTo(W/2+102,H-190); x.stroke();
     }
-    drawJK(); drawBM(); drawJA(); drawPG(); drawPS(); drawSN(); drawRF();
+    function draw3DSN(){
+      const c=document.getElementById('art-3dsn'); if(!c) return; const x=c.getContext('2d'); const W=c.width,H=c.height;
+      x.clearRect(0,0,W,H);
+      const g=x.createLinearGradient(0,0,0,H); g.addColorStop(0,'#e0f2fe'); g.addColorStop(1,'#0ea5e9'); x.fillStyle=g; x.fillRect(0,0,W,H);
+      const cx=W/2, cy=H/2, s=95;
+      const pts=[[-1,-1,-1],[1,-1,-1],[-1,1,-1],[1,1,-1],[-1,-1,1],[1,-1,1],[-1,1,1],[1,1,1]].map(([a,b,c3])=>({x:cx+(a-b)*s*0.75,y:cy+(a+b)*s*0.4-c3*s*0.55}));
+      x.strokeStyle='#bae6fd'; x.lineWidth=2;
+      [[0,1],[0,2],[0,4],[1,3],[1,5],[2,3],[2,6],[3,7],[4,5],[4,6],[5,7],[6,7]].forEach(([a,b])=>{x.beginPath();x.moveTo(pts[a].x,pts[a].y);x.lineTo(pts[b].x,pts[b].y);x.stroke();});
+      x.fillStyle='#22c55e'; [[-25,5],[-4,-6],[15,-17]].forEach(([dx,dy],i)=>{x.beginPath();x.arc(cx+dx,cy+dy,16-i*2,0,Math.PI*2);x.fill();});
+      x.fillStyle='#ef4444'; x.beginPath(); x.arc(cx+55,cy+8,12,0,Math.PI*2); x.fill();
+    }
+    drawJK(); drawBM(); drawJA(); drawPG(); drawPS(); drawSN(); drawRF(); draw3DSN();
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Introduce a new, modernized 3D variant of Snake that plays inside a water-filled cube with wrap-around walls and improved visuals. 
- Add the game to the existing launcher so it is discoverable alongside the other mini-games.

### Description
- Added a new game file `3d-snake/index.html` implementing a 3D-projected cube arena, projection/render helpers, and a responsive UI panel. 
- Implemented gameplay: snake starts with 3 segments, moves with `W/A/S/D` (up/left/down/right) and `ArrowUp`/`ArrowDown` for depth, wraps on all six walls, grows by one segment per apple, and dies on self-collision showing a GAME OVER overlay with score and a Play Again button. 
- Rendered snake visuals (green/yellow alternating segments, black diamond pattern, red forked tongue and fangs) and apple art, plus cube wireframe and depth-sorted drawing. 
- Updated `games/index.html` to add a launcher card and preview canvas art (`draw3DSN`) for 3D-Snake so it appears in the game grid.

### Testing
- Ran the test suite with `npm test --silent` and all tests passed (utility tests and existing snake tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092a78ce948329bc6df2e75e383e12)