### PR TITLE
3D-Snake: depth shading, portal wrap animation, richer snake visuals, and multi-mode gameplay

### DIFF
--- a/3d-snake/index.html
+++ b/3d-snake/index.html
@@ -8,7 +8,7 @@
     :root{--bg:#020617;--panel:#0f172a;--ink:#e2e8f0;--accent:#22d3ee;}
     *{box-sizing:border-box}
     body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial,sans-serif;background:radial-gradient(circle at top,#082f49 0%,#020617 58%);color:var(--ink);min-height:100vh;display:grid;place-items:center;padding:20px}
-    .game-shell{width:min(1100px,95vw);display:grid;grid-template-columns:1fr 300px;gap:18px}
+    .game-shell{width:min(1200px,97vw);display:grid;grid-template-columns:1fr 300px;gap:18px}
     canvas{width:100%;aspect-ratio:16/10;background:linear-gradient(180deg,#0ea5e9,#0b1024 40%,#020617);border-radius:18px;border:1px solid #33415566;box-shadow:0 20px 50px #000a}
     .panel{background:linear-gradient(180deg,#0f172aee,#020617ee);border:1px solid #33415566;border-radius:18px;padding:16px}
     .score{font-size:36px;font-weight:900;color:#67e8f9;margin:6px 0 20px}
@@ -20,7 +20,7 @@
     .stage{position:relative}
     .settings{margin-top:18px;padding-top:16px;border-top:1px solid #33415588}
     .settings label{display:block;font-size:14px;margin-bottom:6px}
-    .settings input{width:100%}
+    .settings input,.settings select{width:100%}
     .settings .value{color:#67e8f9;font-weight:700}
     .settings button{margin-top:10px;width:100%;border:none;background:linear-gradient(90deg,#22d3ee,#0ea5e9);color:#001;padding:10px 14px;border-radius:999px;font-weight:800;cursor:pointer}
     @media(max-width:900px){.game-shell{grid-template-columns:1fr}}
@@ -29,7 +29,7 @@
 <body>
   <div class="game-shell">
     <div class="stage">
-      <canvas id="game" width="1200" height="760"></canvas>
+      <canvas id="game" width="1320" height="820"></canvas>
       <div class="overlay" id="overlay">
         <div>
           <h2>GAME OVER</h2>
@@ -52,6 +52,12 @@
         <strong>Game Settings</strong>
         <label for="speedRange">Snake speed: <span id="speedLabel" class="value">Slow</span></label>
         <input id="speedRange" type="range" min="120" max="420" step="20" value="280" />
+        <label for="modeSelect" style="margin-top:12px">Mode</label>
+        <select id="modeSelect">
+          <option value="apple">Classic: stationary apples</option>
+          <option value="mouse">Hunt mouse: moving mouse target</option>
+          <option value="mixed">Mixed: apples + mice spawn</option>
+        </select>
         <button id="startBtn">Start Game</button>
       </div>
     </aside>
@@ -68,8 +74,10 @@ const restartBtn = document.getElementById('restartBtn');
 const speedRange = document.getElementById('speedRange');
 const speedLabel = document.getElementById('speedLabel');
 const startBtn = document.getElementById('startBtn');
+const modeSelect = document.getElementById('modeSelect');
 
-let snake, dir, nextDir, apple, score, over, running=false, acc=0;
+let snake, dir, nextDir, score, over, running=false, acc=0;
+let mode='apple', targets=[], portals=[];
 let speedMs = Number(speedRange.value);
 
 const dirs = {
@@ -86,12 +94,26 @@ function updateSpeedLabel(){
 
 function reset(){
   snake=[{x:3,y:4,z:4},{x:2,y:4,z:4},{x:1,y:4,z:4}];
-  dir=dirs.right; nextDir=dir; score=0; over=false; acc=0;
-  placeApple(); scoreEl.textContent = score; overlay.classList.remove('show');
+  dir=dirs.right; nextDir=dir; score=0; over=false; acc=0; portals=[];
+  initTargets();
+  scoreEl.textContent = score; overlay.classList.remove('show');
 }
-function placeApple(){
-  do { apple={x:(Math.random()*SIZE)|0,y:(Math.random()*SIZE)|0,z:(Math.random()*SIZE)|0}; }
-  while(snake.some(s=>eq(s,apple)));
+function randomFreeCell(){
+  let c;
+  do { c={x:(Math.random()*SIZE)|0,y:(Math.random()*SIZE)|0,z:(Math.random()*SIZE)|0}; }
+  while(snake.some(s=>eq(s,c)) || targets.some(t=>eq(t.pos,c)));
+  return c;
+}
+function spawnTarget(type){ targets.push({type, pos: randomFreeCell(), moveAcc: 0}); }
+function initTargets(){
+  targets=[];
+  if(mode==='mouse') spawnTarget('mouse');
+  else { spawnTarget('apple'); if(mode==='mixed') spawnTarget(Math.random()<0.5?'mouse':'apple'); }
+}
+function replenishTargets(){
+  if(mode==='apple') while(targets.length<1) spawnTarget('apple');
+  else if(mode==='mouse') while(targets.length<1) spawnTarget('mouse');
+  else while(targets.length<2) spawnTarget(Math.random()<0.5?'mouse':'apple');
 }
 
 window.addEventListener('keydown', e=>{
@@ -103,36 +125,35 @@ window.addEventListener('keydown', e=>{
 });
 
 restartBtn.onclick=()=>{ reset(); running=true; };
-startBtn.onclick=()=>{ speedMs = Number(speedRange.value); reset(); running=true; };
+startBtn.onclick=()=>{ speedMs = Number(speedRange.value); mode = modeSelect.value; reset(); running=true; };
 speedRange.addEventListener('input', ()=>{ speedMs = Number(speedRange.value); updateSpeedLabel(); });
 
 function project(p){
-  const cx=canvas.width*0.52, cy=canvas.height*0.64;
-  const u=48;
+  const cx=canvas.width*0.52, cy=canvas.height*0.72;
+  const u=62;
   const sx=u, sy=u*0.5, sz=u;
   return {x:cx+(p.x-p.y)*sx,y:cy+(p.x+p.y)*sy - p.z*sz, zOrder:p.x+p.y+p.z};
 }
 
 function drawCube(){
+  const face = (points, fill) => { ctx.fillStyle=fill; ctx.beginPath(); ctx.moveTo(points[0].x,points[0].y); for(let i=1;i<points.length;i++) ctx.lineTo(points[i].x,points[i].y); ctx.closePath(); ctx.fill(); };
+  face([project({x:0,y:0,z:0}),project({x:SIZE,y:0,z:0}),project({x:SIZE,y:SIZE,z:0}),project({x:0,y:SIZE,z:0})],'rgba(12,38,68,0.16)');
+  face([project({x:0,y:SIZE,z:0}),project({x:SIZE,y:SIZE,z:0}),project({x:SIZE,y:SIZE,z:SIZE}),project({x:0,y:SIZE,z:SIZE})],'rgba(7,26,47,0.24)');
+  face([project({x:SIZE,y:0,z:0}),project({x:SIZE,y:SIZE,z:0}),project({x:SIZE,y:SIZE,z:SIZE}),project({x:SIZE,y:0,z:SIZE})],'rgba(8,30,56,0.21)');
+
   const corners=[];
   for(const z of [0,SIZE]) for(const y of [0,SIZE]) for(const x of [0,SIZE]) corners.push(project({x,y,z}));
   const edge = [[0,1],[0,2],[0,4],[1,3],[1,5],[2,3],[2,6],[3,7],[4,5],[4,6],[5,7],[6,7]];
 
-  ctx.strokeStyle='rgba(125,211,252,.12)'; ctx.lineWidth=1;
+  ctx.strokeStyle='rgba(125,211,252,.13)'; ctx.lineWidth=1;
   for(let i=1;i<SIZE;i++){
     for(let j=0;j<=SIZE;j+=SIZE){
-      let a=project({x:i,y:0,z:j}), b=project({x:i,y:SIZE,z:j});
-      ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
-      a=project({x:0,y:i,z:j}); b=project({x:SIZE,y:i,z:j});
-      ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
-      a=project({x:j,y:0,z:i}); b=project({x:j,y:SIZE,z:i});
-      ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
-      a=project({x:0,y:j,z:i}); b=project({x:SIZE,y:j,z:i});
-      ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
-      a=project({x:0,y:i,z:0}); b=project({x:0,y:i,z:SIZE});
-      ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
-      a=project({x:i,y:0,z:0}); b=project({x:i,y:0,z:SIZE});
-      ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
+      let a=project({x:i,y:0,z:j}), b=project({x:i,y:SIZE,z:j}); ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
+      a=project({x:0,y:i,z:j}); b=project({x:SIZE,y:i,z:j}); ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
+      a=project({x:j,y:0,z:i}); b=project({x:j,y:SIZE,z:i}); ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
+      a=project({x:0,y:j,z:i}); b=project({x:SIZE,y:j,z:i}); ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
+      a=project({x:0,y:i,z:0}); b=project({x:0,y:i,z:SIZE}); ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
+      a=project({x:i,y:0,z:0}); b=project({x:i,y:0,z:SIZE}); ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
     }
   }
 
@@ -146,55 +167,95 @@ function drawApple(cell){
   ctx.fillStyle='#ef4444'; ctx.beginPath(); ctx.arc(p.x,p.y,s*0.55,0,Math.PI*2); ctx.fill();
   ctx.strokeStyle='#166534'; ctx.lineWidth=3; ctx.beginPath(); ctx.moveTo(p.x+2,p.y-s*0.5); ctx.lineTo(p.x+8,p.y-s*0.85); ctx.stroke();
 }
+function drawMouse(cell){
+  const p = project({x:cell.x+0.5,y:cell.y+0.5,z:cell.z+0.5});
+  ctx.fillStyle = '#9ca3af';
+  ctx.beginPath(); ctx.ellipse(p.x,p.y,14,9,0,0,Math.PI*2); ctx.fill();
+  ctx.beginPath(); ctx.ellipse(p.x-9,p.y-5,5,5,0,0,Math.PI*2); ctx.fill();
+  ctx.beginPath(); ctx.ellipse(p.x+9,p.y-5,5,5,0,0,Math.PI*2); ctx.fill();
+  ctx.fillStyle = '#111827'; ctx.beginPath(); ctx.arc(p.x+7,p.y,1.8,0,Math.PI*2); ctx.fill(); ctx.beginPath(); ctx.arc(p.x-7,p.y,1.8,0,Math.PI*2); ctx.fill();
+  ctx.strokeStyle = '#fda4af'; ctx.lineWidth = 2; ctx.beginPath(); ctx.moveTo(p.x-13,p.y+2); ctx.quadraticCurveTo(p.x-25,p.y+6,p.x-30,p.y+14); ctx.stroke();
+}
+function drawPortals(){
+  for(const portal of portals){
+    const alpha = Math.max(0, 1 - portal.life / 850); if(alpha<=0) continue;
+    [portal.from, portal.to].forEach((cell,idx)=>{
+      const p = project({x:cell.x+0.5,y:cell.y+0.5,z:cell.z+0.5});
+      const base = 16 + portal.life * 0.018 + idx * 2;
+      for(let i=0;i<3;i++){
+        ctx.strokeStyle = `rgba(${i===1?34:56},${i===1?211:189},255,${alpha*(0.75-i*0.2)})`;
+        ctx.lineWidth = 2.5 - i*0.5;
+        ctx.beginPath(); ctx.ellipse(p.x,p.y,base+i*6,base*0.55+i*4,0.3,0,Math.PI*2); ctx.stroke();
+      }
+    });
+  }
+}
 
 function drawSnake(){
   const points = snake.map(s => project({x:s.x+0.5,y:s.y+0.5,z:s.z+0.5}));
   if(points.length > 1){
-    ctx.strokeStyle='rgba(6,78,59,0.95)';
-    ctx.lineJoin='round'; ctx.lineCap='round'; ctx.lineWidth=24;
-    ctx.beginPath(); ctx.moveTo(points[0].x, points[0].y);
-    for(let i=1;i<points.length;i++) ctx.lineTo(points[i].x, points[i].y);
-    ctx.stroke();
-
-    ctx.strokeStyle='rgba(34,197,94,0.95)'; ctx.lineWidth=17;
-    ctx.beginPath(); ctx.moveTo(points[0].x, points[0].y);
-    for(let i=1;i<points.length;i++) ctx.lineTo(points[i].x, points[i].y);
-    ctx.stroke();
+    ctx.strokeStyle='rgba(6,78,59,0.95)'; ctx.lineJoin='round'; ctx.lineCap='round'; ctx.lineWidth=30;
+    ctx.beginPath(); ctx.moveTo(points[0].x, points[0].y); for(let i=1;i<points.length;i++) ctx.lineTo(points[i].x, points[i].y); ctx.stroke();
+    ctx.strokeStyle='rgba(34,197,94,0.95)'; ctx.lineWidth=22;
+    ctx.beginPath(); ctx.moveTo(points[0].x, points[0].y); for(let i=1;i<points.length;i++) ctx.lineTo(points[i].x, points[i].y); ctx.stroke();
   }
 
   points.slice().reverse().forEach((p, idx)=>{
-    const t = idx/(points.length-1 || 1);
-    const r = 7 + (1-t)*6;
-    ctx.fillStyle = idx === points.length-1 ? '#a3e635' : '#4ade80';
+    const t = idx/(points.length-1 || 1); const r = 8 + (1-t)*7;
+    ctx.fillStyle = idx === points.length-1 ? '#bef264' : '#4ade80';
     ctx.beginPath(); ctx.arc(p.x,p.y,r,0,Math.PI*2); ctx.fill();
+    if(idx > 0 && idx < points.length-1){ ctx.fillStyle='#0f172a'; ctx.beginPath(); ctx.ellipse(p.x,p.y,r*0.72,r*0.26,idx%2?0.32:-0.32,0,Math.PI*2); ctx.fill(); }
   });
 
   const head = points[0];
-  ctx.fillStyle='#f8fafc';
-  ctx.beginPath(); ctx.arc(head.x-6,head.y-6,2.3,0,Math.PI*2); ctx.fill();
-  ctx.beginPath(); ctx.arc(head.x+6,head.y-6,2.3,0,Math.PI*2); ctx.fill();
+  ctx.fillStyle='#f8fafc'; ctx.beginPath(); ctx.arc(head.x-7,head.y-7,2.5,0,Math.PI*2); ctx.fill(); ctx.beginPath(); ctx.arc(head.x+7,head.y-7,2.5,0,Math.PI*2); ctx.fill();
+  ctx.fillStyle = '#ffffff';
+  ctx.beginPath(); ctx.moveTo(head.x-4,head.y+4); ctx.lineTo(head.x-1,head.y+14); ctx.lineTo(head.x+1,head.y+4); ctx.closePath(); ctx.fill();
+  ctx.beginPath(); ctx.moveTo(head.x+4,head.y+4); ctx.lineTo(head.x+1,head.y+14); ctx.lineTo(head.x-1,head.y+4); ctx.closePath(); ctx.fill();
+}
+
+function moveMice(dt){
+  for(const t of targets){
+    if(t.type !== 'mouse') continue;
+    t.moveAcc += dt;
+    if(t.moveAcc < 1300) continue;
+    t.moveAcc = 0;
+    const options = [dirs.left, dirs.right, dirs.up, dirs.down, dirs.in, dirs.out].sort(()=>Math.random()-0.5);
+    for(const d of options){
+      const next = {x:t.pos.x+d.x,y:t.pos.y+d.y,z:t.pos.z+d.z};
+      if(next.x<0||next.y<0||next.z<0||next.x>=SIZE||next.y>=SIZE||next.z>=SIZE) continue;
+      if(snake.some(s=>eq(s,next)) || targets.some(other=>other!==t&&eq(other.pos,next))) continue;
+      t.pos = next; break;
+    }
+  }
 }
 
 function tick(){
   dir=nextDir;
-  const n={x:wrap(snake[0].x+dir.x),y:wrap(snake[0].y+dir.y),z:wrap(snake[0].z+dir.z)};
+  const head = snake[0];
+  const raw={x:head.x+dir.x,y:head.y+dir.y,z:head.z+dir.z};
+  const n={x:wrap(raw.x),y:wrap(raw.y),z:wrap(raw.z)};
+  if(raw.x!==n.x || raw.y!==n.y || raw.z!==n.z) portals.push({from:{...head},to:{...n},life:0});
   if(snake.some(s=>eq(s,n))){over=true; running=false; overlay.classList.add('show'); finalScoreEl.textContent=`Score: ${score}`; return;}
   snake.unshift(n);
-  if(eq(n,apple)){score++; scoreEl.textContent=score; placeApple();}
+  const hit = targets.findIndex(t=>eq(t.pos,n));
+  if(hit>=0){score++; scoreEl.textContent=score; targets.splice(hit,1); replenishTargets();}
   else snake.pop();
 }
 
 function draw(){
   ctx.clearRect(0,0,canvas.width,canvas.height);
   drawCube();
-  drawApple(apple);
+  drawPortals();
+  targets.slice().sort((a,b)=>(a.pos.x+a.pos.y+a.pos.z)-(b.pos.x+b.pos.y+b.pos.z)).forEach(t=>t.type==='apple'?drawApple(t.pos):drawMouse(t.pos));
   drawSnake();
 }
 
 let last=performance.now();
 function frame(t){
   const dt=t-last; last=t;
-  if(running && !over){acc+=dt; while(acc>=speedMs){tick(); acc-=speedMs;}}
+  portals.forEach(p=>{p.life += dt;}); portals = portals.filter(p=>p.life < 850);
+  if(running && !over){acc+=dt; moveMice(dt); while(acc>=speedMs){tick(); acc-=speedMs;}}
   draw(); requestAnimationFrame(frame);
 }
 updateSpeedLabel();


### PR DESCRIPTION
### Motivation
- Improve depth perception so apples and snake position inside the cube are easier to judge. 
- Make wall-wrapping visually clear with a portal-like animation at both entry and exit points. 
- Make the snake look more characterful and readable with cartoony details while increasing visual scale so the cube fills more of the screen. 
- Add gameplay variety with selectable modes including a moving target (mouse) and mixed spawns.

### Description
- Increased canvas and world scale by bumping the canvas size and projection scale (`canvas` size, `u`, and `project()` offsets) so the cube fills more of the viewport. 
- Added face shading for the cube (`face()` calls in `drawCube()`) to darken outer faces while keeping grid/edges to improve depth cues. 
- Reworked snake rendering to use thicker strokes and layered fills, added larger dorsal black diamonds (drawn as ellipses) and cartoony fangs on the head to increase readability and character. 
- Implemented portal wall-wrap visuals with a `portals` array, lifecycle (`life`) tracking, `drawPortals()` rendering, and logic in `tick()` to push portal pairs when a move wraps across a boundary. 
- Replaced single `apple` with a generic `targets` system and added UI `select` for modes (`apple`, `mouse`, `mixed`) in the settings panel. 
- Implemented mouse target rendering (`drawMouse()`), slower step-by-step movement (`moveMice()`), bounds-checked movement that cannot pass through walls, and spawn/replenish logic (`spawnTarget()`, `initTargets()`, `replenishTargets()`). 
- Adjusted main loop to update portal lifetimes and drive mouse movement (`moveMice(dt)`), and reordered drawing so portals and targets render correctly relative to the snake.

### Testing
- Ran the test suite with `npm test --silent` and the automated tests completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10e2ecfe748329ae47bbfa20a46368)